### PR TITLE
feat: adding commit fixes and descriptions to the rules' properties

### DIFF
--- a/src/interfaces/analysis-result.interface.ts
+++ b/src/interfaces/analysis-result.interface.ts
@@ -18,6 +18,14 @@ interface CommitChangeLine {
   lineChange: 'removed' | 'added' | 'none';
 }
 
+export interface RuleProperties {
+  tags: string[];
+  exampleCommitFixes?: ExampleCommitFix[];
+  exampleCommitDescriptions?: string[];
+  precision: string;
+  cwe?: string[];
+}
+
 interface ExampleCommitFix {
   commitURL: string;
   lines: CommitChangeLine[];

--- a/src/sarif_converter.ts
+++ b/src/sarif_converter.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-unresolved
 import { Log, ReportingConfiguration, ReportingDescriptor, Result } from 'sarif';
 
-import { IAnalysisResult, IFileSuggestion } from './interfaces/analysis-result.interface';
+import { IAnalysisResult, IFileSuggestion, RuleProperties } from './interfaces/analysis-result.interface';
 
 interface Fingerprint {
   version: number;
@@ -66,6 +66,13 @@ const getTools = (analysisResults: IAnalysisResult, suggestions: ISarifSuggestio
     // payload comes as URIencoded
     const language = suggestion.id.split('%2F')[0];
     const suggestionId = `${language}/${suggestion.rule}`;
+    const ruleProperties: RuleProperties = {
+      tags: [language, ...suggestion.tags, ...suggestion.categories],
+      exampleCommitFixes: suggestion.exampleCommitFixes,
+      exampleCommitDescriptions: suggestion.exampleCommitDescriptions,
+      precision: 'very-high'
+    };
+
     const rule = {
       id: suggestionId,
       name: suggestion.rule,
@@ -79,10 +86,7 @@ const getTools = (analysisResults: IAnalysisResult, suggestions: ISarifSuggestio
         markdown: suggestion.text,
         text: '',
       },
-      properties: {
-        tags: [language, ...suggestion.tags, ...suggestion.categories],
-        precision: 'very-high',
-      } as { tags: string[]; precision: string; cwe?: string[] },
+      properties: ruleProperties
     };
 
     if (suggestion.cwe?.length) {

--- a/tests/sarif_converter.spec.ts
+++ b/tests/sarif_converter.spec.ts
@@ -67,4 +67,38 @@ describe('Sarif Convertor', () => {
     expect((sarifResults.runs[0].results as any)[4].fingerprints[2]).toEqual('78d8a8779142d82cf9be9da7a167e8e06236ab0a67d324143494650a5e4badf2');
 
   });
+
+  it('should contain example commit fixes', () => {
+    const sarifResults = getSarif(analysisResultsWithoutFingerprinting as unknown as IAnalysisResult);
+    const validationResult = jsonschema.validate(sarifResults, sarifSchema);
+    expect(validationResult.errors.length).toEqual(0);
+
+    const rules = sarifResults?.runs[0].tool?.driver?.rules;
+    let exampleCommitFixes;
+    if (rules !== undefined)
+      exampleCommitFixes = rules[6].properties?.exampleCommitFixes;
+
+    expect(exampleCommitFixes.length).toBeGreaterThan(0);
+    let exampleCommitFix = exampleCommitFixes[0];
+    expect(exampleCommitFix?.commitURL).toBeTruthy();
+    expect(exampleCommitFix?.lines).toBeTruthy();
+
+    const exampleCommitFixLine = exampleCommitFix?.lines[0];
+    expect(exampleCommitFixLine?.line).toBeTruthy();
+    expect(exampleCommitFixLine?.lineNumber).toBeTruthy();
+    expect(exampleCommitFixLine?.lineChange).toBeTruthy();
+  });
+
+  it('should contain example commit descriptions', () => {
+    const sarifResults = getSarif(analysisResultsWithoutFingerprinting as unknown as IAnalysisResult);
+    const validationResult = jsonschema.validate(sarifResults, sarifSchema);
+    expect(validationResult.errors.length).toEqual(0);
+
+    const rules = sarifResults?.runs[0].tool?.driver?.rules;
+    let exampleCommitDescriptions;
+    if (rules !== undefined)
+      exampleCommitDescriptions = rules[0].properties?.exampleCommitDescriptions;
+
+    expect(exampleCommitDescriptions.length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
COD-114 Storing automatic fix examples on our DB

🗄️ Example commit fixes need to be stored in our database.

- [x] Ready for review
- [x] Linked to Jira ticket

#### What does this PR do?
✅ Exporting the `ExampleCommitFix` interface to make it accessible to the Sarif Converter.
✅ Updating the `properties` object on `rules` instances of the Sarif Converter to be able to store them.
✅ Updating the Sarif Converter spec to test for the presence of the exemple `ExampleCommitFix`.

#### Where should the reviewer start?
- Check the new `RuleProperty` type and its use.
- Run the `tests/sarif_converter.spec.ts` test.

#### How should this be manually tested?
- Run the `tests/sarif_converter.spec.ts` test.
