### PR TITLE
[COD-268] fix: upgrade fast-globs to snyk patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "lodash.union": "^4.6.0",
     "ignore": "^5.1.8",
     "queue": "^6.0.1",
-    "fast-glob": "^3.2.5",
+    "@snyk/fast-glob": "^3.2.6-patch",
     "micromatch": "^4.0.2",
     "flat-cache": "^3.0.4",
     "@types/uuid": "^8.3.0",

--- a/src/files.ts
+++ b/src/files.ts
@@ -1,6 +1,6 @@
 import * as nodePath from 'path';
 import * as fs from 'fs';
-import fg from 'fast-glob';
+import fg from '@snyk/fast-glob';
 import micromatch from 'micromatch';
 import crypto from 'crypto';
 import union from 'lodash.union';

--- a/tests/git.analysis.spec.ts
+++ b/tests/git.analysis.spec.ts
@@ -94,7 +94,7 @@ describe('Functional test of analysis', () => {
       });
 
       // Test DC JSON format first
-      expect(Object.keys(bundle.analysisResults.suggestions).length).toEqual(119);
+      expect(Object.keys(bundle.analysisResults.suggestions).length).toEqual(121);
 
       const cweSuggestion = Object.values(bundle.analysisResults.suggestions).find(
         s => s.id === 'java%2Fdc_interfile_project%2FPT',
@@ -104,8 +104,8 @@ describe('Functional test of analysis', () => {
       expect(cweSuggestion?.title).toBeTruthy();
       expect(cweSuggestion?.text).toBeTruthy();
 
-      expect(bundle.sarifResults?.runs[0].results?.length).toEqual(119);
-      expect(bundle.sarifResults?.runs[0].tool?.driver.rules?.length).toEqual(119);
+      expect(bundle.sarifResults?.runs[0].results?.length).toEqual(121);
+      expect(bundle.sarifResults?.runs[0].tool?.driver.rules?.length).toEqual(121);
 
       const cweRule = bundle.sarifResults?.runs[0].tool?.driver.rules?.find(r => r.id === 'java/PT');
       expect(cweRule?.properties?.cwe).toContain('CWE-23');


### PR DESCRIPTION
[COD-268]
- [x] Ready for review
- [ ] Linked to Jira ticket

#### What does this PR do?
This Pr upgrades to our patched version of fast-globs

#### Any background context you want to provide?
Code Client is used in the snyk cli which is an open source repo and can not have any vulns. glob-parent was a dependancy in the dependancy tree with a regex ddos vuln that snyk found after contecting the maintainer he was very rude and did not seem to want to push the fixes that had been approved. So this is a temporary fix until the maintainer pushes the fixes.


[COD-268]: https://snyksec.atlassian.net/browse/COD-268