### PR TITLE
fix: add catergories in a seperate property field in the property bag

### DIFF
--- a/src/interfaces/analysis-result.interface.ts
+++ b/src/interfaces/analysis-result.interface.ts
@@ -20,6 +20,7 @@ interface CommitChangeLine {
 
 export interface RuleProperties {
   tags: string[];
+  categories: string[];
   exampleCommitFixes?: ExampleCommitFix[];
   exampleCommitDescriptions?: string[];
   precision: string;

--- a/src/sarif_converter.ts
+++ b/src/sarif_converter.ts
@@ -51,9 +51,12 @@ function getSuggestions(analysisResults: IAnalysisResult): ISarifSuggestions {
     }
   }
   return suggestions;
-};
+}
 
-function getRulesAndAllIssues(analysisResults: IAnalysisResult, allIssuesBySuggestions: ISarifSuggestions): { rules: ReportingDescriptor[], allIssues: ISarifSuggestion[] } {
+function getRulesAndAllIssues(
+  analysisResults: IAnalysisResult,
+  allIssuesBySuggestions: ISarifSuggestions,
+): { rules: ReportingDescriptor[]; allIssues: ISarifSuggestion[] } {
   let ruleIndex = 0;
   const rules: ReportingDescriptor[] = [];
   const allIssues: ISarifSuggestion[] = [];
@@ -67,10 +70,11 @@ function getRulesAndAllIssues(analysisResults: IAnalysisResult, allIssuesBySugge
     const language = suggestion.id.split('%2F')[0];
     const suggestionId = `${language}/${suggestion.rule}`;
     const ruleProperties: RuleProperties = {
-      tags: [language, ...suggestion.tags, ...suggestion.categories],
+      tags: [language, ...suggestion.tags],
+      categories: suggestion.categories,
       exampleCommitFixes: suggestion.exampleCommitFixes,
       exampleCommitDescriptions: suggestion.exampleCommitDescriptions,
-      precision: 'very-high'
+      precision: 'very-high',
     };
 
     const rule = {
@@ -86,7 +90,7 @@ function getRulesAndAllIssues(analysisResults: IAnalysisResult, allIssuesBySugge
         markdown: suggestion.text,
         text: '',
       },
-      properties: ruleProperties
+      properties: ruleProperties,
     };
 
     if (suggestion.cwe?.length) {
@@ -106,12 +110,11 @@ function getRulesAndAllIssues(analysisResults: IAnalysisResult, allIssuesBySugge
         id: suggestionId,
         text: suggestion.message,
       });
-      
     });
     ruleIndex += 1;
   }
   return { rules, allIssues };
-};
+}
 
 function getResults(allIssues: ISarifSuggestion[]): Result[] {
   const output = [];
@@ -142,7 +145,7 @@ function getResults(allIssues: ISarifSuggestion[]): Result[] {
             },
           },
         },
-      ]
+      ],
     };
 
     if (issue.fingerprints) {
@@ -223,7 +226,7 @@ function getResults(allIssues: ISarifSuggestion[]): Result[] {
     output.push(newResult);
   }
   return output;
-};
+}
 
 //custom string splice implementation
 export function stringSplice(str: string, index: number, count: number, add?: string) {

--- a/tests/__snapshots__/api.spec.ts.snap
+++ b/tests/__snapshots__/api.spec.ts.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Requests to public API test successful workflow with and without linters 1`] = `
+Object {
+  "2": Array [
+    Object {
+      "cols": Array [
+        8,
+        27,
+      ],
+      "fingerprints": Array [
+        Object {
+          "fingerprint": "f8e3391465a47f6586489cffd1f44ae47a1c4885c722de596d6eb931fe43bb16",
+          "version": 0,
+        },
+      ],
+      "markers": Array [],
+      "rows": Array [
+        5,
+        5,
+      ],
+    },
+  ],
+  "3": Array [
+    Object {
+      "cols": Array [
+        6,
+        25,
+      ],
+      "fingerprints": Array [
+        Object {
+          "fingerprint": "3e40a81739245db8fff4903a7e28e08bffa03486a677e7c91594cfdf15fb5a1d",
+          "version": 0,
+        },
+        Object {
+          "fingerprint": "57664a44.2c254dac.98501263.9e345555.da547a36.9509b717.a713c1c8.45d76bdf.57664a44.2c254dac.98501263.9e345555.da547a36.9509b717.a713c1c8.45d76bdf",
+          "version": 1,
+        },
+      ],
+      "markers": Array [
+        Object {
+          "msg": Array [
+            25,
+            36,
+          ],
+          "pos": Array [
+            Object {
+              "cols": Array [
+                7,
+                14,
+              ],
+              "file": "/AnnotatorTest.cpp",
+              "rows": Array [
+                8,
+                8,
+              ],
+            },
+          ],
+        },
+        Object {
+          "msg": Array [
+            45,
+            57,
+          ],
+          "pos": Array [
+            Object {
+              "cols": Array [
+                6,
+                25,
+              ],
+              "file": "/AnnotatorTest.cpp",
+              "rows": Array [
+                10,
+                10,
+              ],
+            },
+          ],
+        },
+      ],
+      "rows": Array [
+        10,
+        10,
+      ],
+    },
+  ],
+}
+`;

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -405,55 +405,7 @@ describe('Requests to public API', () => {
         expect(suggestion.tags).toEqual(['maintenance', 'express', 'server', 'helmet']);
         expect(Object.keys(response.value.analysisResults.files).length).toEqual(4);
         const filePath = `/AnnotatorTest.cpp`;
-        expect(response.value.analysisResults.files[filePath]).toEqual({
-          '2': [
-            {
-              cols: [8, 27],
-              markers: [],
-              rows: [5, 5],
-              fingerprints: [
-                {
-                  fingerprint: 'f8e3391465a47f6586489cffd1f44ae47a1c4885c722de596d6eb931fe43bb16',
-                  version: 0,
-                },
-              ],
-            },
-          ],
-          '3': [
-            {
-              cols: [6, 25],
-              markers: [
-                {
-                  msg: [25, 36],
-                  pos: [
-                    {
-                      cols: [7, 14],
-                      rows: [8, 8],
-                      file: filePath,
-                    },
-                  ],
-                },
-                {
-                  msg: [45, 57],
-                  pos: [
-                    {
-                      cols: [6, 25],
-                      rows: [10, 10],
-                      file: filePath,
-                    },
-                  ],
-                },
-              ],
-              rows: [10, 10],
-              fingerprints: [
-                {
-                  fingerprint: '3e40a81739245db8fff4903a7e28e08bffa03486a677e7c91594cfdf15fb5a1d',
-                  version: 0,
-                },
-              ],
-            },
-          ],
-        });
+        expect(response.value.analysisResults.files[filePath]).toMatchSnapshot();
 
         expect(response.value.analysisResults.timing.analysis).toBeGreaterThanOrEqual(
           response.value.analysisResults.timing.fetchingCode,


### PR DESCRIPTION
- [ ] Ready for review

#### What does this PR do?
This PR removes the possibility of having a tag break the category filtering by giving categories it own place in the property bag

This also changes the analysisResults.files[filePath] test to a snapshot due to constant updating of the fingerprinting
