### PR TITLE
feat: axios agent keep alive to reuse connections

### DIFF
--- a/src/axios.ts
+++ b/src/axios.ts
@@ -7,7 +7,6 @@ const agentOptions = {
   keepAlive: true,
   maxSockets: 100, // Maximum number of sockets to allow per host. Defaults to Infinity.
   maxFreeSockets: 10,
-  // timeout: 60000, // active socket keepalive for 60 seconds
   freeSocketTimeout: 60000, // // Maximum number of sockets to leave open for 60 seconds in a free state. Only relevant if keepAlive is set to true. Defaults to 256.
   socketActiveTTL: 1000 * 60 * 10,
 };

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -1,11 +1,25 @@
 import axios, { AxiosRequestConfig, AxiosError, AxiosResponse } from 'axios';
+import http from 'http';
+import https from 'https';
 import emitter from './emitter';
+
+const agentOptions = {
+  keepAlive: true,
+  maxSockets: 100, // Maximum number of sockets to allow per host. Defaults to Infinity.
+  maxFreeSockets: 10,
+  // timeout: 60000, // active socket keepalive for 60 seconds
+  freeSocketTimeout: 60000, // // Maximum number of sockets to leave open for 60 seconds in a free state. Only relevant if keepAlive is set to true. Defaults to 256.
+  socketActiveTTL: 1000 * 60 * 10,
+};
 
 const axios_ = axios.create({
   responseType: 'json',
   headers: {
     'Content-Type': 'application/json;charset=utf-8',
   },
+  // keepAlive pools and reuses TCP connections, so it's faster
+  httpAgent: new http.Agent(agentOptions),
+  httpsAgent: new https.Agent(agentOptions),
 });
 
 axios_.interceptors.request.use(


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Linked to Jira ticket

#### What does this PR do?

Under heavy load i realized, that we don't reuse connections and establish new one al the time. At some point, we just can't make a new connection and everything hangs.

This PR aims to solve this by setting special http/https agent with keep alive and granular socket settings

