### PR TITLE
Fix: Propagate --insecure parameter

### DIFF
--- a/src/axios.ts
+++ b/src/axios.ts
@@ -3,12 +3,21 @@ import http from 'http';
 import https from 'https';
 import emitter from './emitter';
 
+// Snyk CLI allow passing --insecure flag which allows self-signed certificates
+// It updates global namespace property ignoreUnknownCA and we can use it in order
+// to pass rejectUnauthorized option to https agent
+export declare interface Global extends NodeJS.Global {
+  ignoreUnknownCA: boolean;
+}
+declare const global: Global;
+
 const agentOptions = {
   keepAlive: true,
   maxSockets: 100, // Maximum number of sockets to allow per host. Defaults to Infinity.
   maxFreeSockets: 10,
   freeSocketTimeout: 60000, // // Maximum number of sockets to leave open for 60 seconds in a free state. Only relevant if keepAlive is set to true. Defaults to 256.
   socketActiveTTL: 1000 * 60 * 10,
+  rejectUnauthorized: !global.ignoreUnknownCA,
 };
 
 const axios_ = axios.create({

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -42,7 +42,7 @@ describe('Requests to public API', () => {
     if (response.type === 'error') return;
     expect(new Set(response.value.configFiles)).toEqual(new Set(['.dcignore', '.gitignore']));
     expect(new Set(response.value.extensions)).toEqual(
-      new Set(['.es', '.es6', '.htm', '.html', '.js', '.jsx', '.py', '.ts', '.tsx', '.vue', '.java']),
+      new Set(['.es', '.es6', '.htm', '.html', '.js', '.jsx', '.py', '.ts', '.tsx', '.vue', '.java', '.java-dummy']),
     );
   });
 
@@ -404,8 +404,9 @@ describe('Requests to public API', () => {
       } while (response.value.status !== AnalysisStatus.done);
 
       expect(Object.keys(response.value.analysisResults.suggestions).length).toEqual(4);
-      expect(new Set(Object.keys(response.value.analysisResults.files)))
-        .toEqual(new Set(['/GitHubAccessTokenScrambler12.java', '/not/ignored/this_should_not_be_ignored.java']));
+      expect(new Set(Object.keys(response.value.analysisResults.files))).toEqual(
+        new Set(['/GitHubAccessTokenScrambler12.java', '/not/ignored/this_should_not_be_ignored.java']),
+      );
 
       // Get analysis results without linters but with severity 3
       do {
@@ -423,8 +424,9 @@ describe('Requests to public API', () => {
       } while (response.value.status !== AnalysisStatus.done);
 
       expect(Object.keys(response.value.analysisResults.suggestions).length).toEqual(2);
-      expect(new Set(Object.keys(response.value.analysisResults.files)))
-        .toEqual(new Set(['/GitHubAccessTokenScrambler12.java', '/not/ignored/this_should_not_be_ignored.java']));
+      expect(new Set(Object.keys(response.value.analysisResults.files))).toEqual(
+        new Set(['/GitHubAccessTokenScrambler12.java', '/not/ignored/this_should_not_be_ignored.java']),
+      );
     },
     TEST_TIMEOUT,
   );

--- a/tests/git.analysis.spec.ts
+++ b/tests/git.analysis.spec.ts
@@ -95,7 +95,7 @@ describe('Functional test of analysis', () => {
       });
 
       // Test DC JSON format first
-      expect(Object.keys(bundle.analysisResults.suggestions).length).toEqual(119);
+      expect(Object.keys(bundle.analysisResults.suggestions).length).toEqual(134);
 
       const cweSuggestion = Object.values(bundle.analysisResults.suggestions).find(
         s => s.id === 'java%2Fdc_interfile_project%2FPT',
@@ -105,8 +105,8 @@ describe('Functional test of analysis', () => {
       expect(cweSuggestion?.title).toBeTruthy();
       expect(cweSuggestion?.text).toBeTruthy();
 
-      expect(bundle.sarifResults?.runs[0].results?.length).toEqual(400);
-      expect(bundle.sarifResults?.runs[0].tool?.driver.rules?.length).toEqual(119);
+      expect(bundle.sarifResults?.runs[0].results?.length).toEqual(442);
+      expect(bundle.sarifResults?.runs[0].tool?.driver.rules?.length).toEqual(134);
 
       const cweRule = bundle.sarifResults?.runs[0].tool?.driver.rules?.find(r => r.id === 'java/PT');
       expect(cweRule?.properties?.cwe).toContain('CWE-23');


### PR DESCRIPTION
To unify behaviour with default `snyk test` command, this PR takes an advantage of https://github.com/snyk/snyk/commit/5ae3182e16929b0d6ac87a976194c599b22835e3#diff-1bc78dd2ada161f97e1a1e595957fbe2487468b6a81191600acf0aa63769ad88R136