### PR TITLE
feat: expose bundle creation logic

### DIFF
--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -46,6 +46,19 @@ import { ISupportedFiles } from './interfaces/files.interface';
 
 const sleep = (duration: number) => new Promise(resolve => setTimeout(resolve, duration));
 
+const ANALYSIS_OPTIONS_DEFAULTS = {
+  baseURL: defaultBaseURL,
+  sessionToken: '',
+  includeLint: false,
+  reachability: false,
+  severity: AnalysisSeverity.info,
+  symlinksEnabled: false,
+  maxPayload: MAX_PAYLOAD,
+  defaultFileIgnores: IGNORES_DEFAULT,
+  sarif: false,
+  source: '',
+}
+
 async function pollAnalysis(
   {
     baseURL,
@@ -239,20 +252,9 @@ function mergeBundleResults(bundle: IFileBundle, analysisData: IBundleResult, li
     analysisResults,
   };
 }
-let analyzeFolderDefaults = {
-  baseURL: defaultBaseURL,
-  sessionToken: '',
-  includeLint: false,
-  reachability: false,
-  severity: AnalysisSeverity.info,
-  symlinksEnabled: false,
-  maxPayload: MAX_PAYLOAD,
-  defaultFileIgnores: IGNORES_DEFAULT,
-  sarif: false,
-  source: '',
-};
+
 export async function analyzeFolders(options: FolderOptions): Promise<IFileBundle> {
-  const analysisOptions: AnalyzeFoldersOptions = { ...analyzeFolderDefaults, ...options };
+  const analysisOptions: AnalyzeFoldersOptions = { ...ANALYSIS_OPTIONS_DEFAULTS, ...options };
   const {
     baseURL,
     sessionToken,
@@ -383,18 +385,8 @@ export async function extendAnalysis(
   );
 }
 
-const analyzeGitDefaults = {
-  baseURL: defaultBaseURL,
-  sessionToken: '',
-  includeLint: false,
-  reachability: false,
-  severity: AnalysisSeverity.info,
-  sarif: false,
-  source: '',
-};
-
 export async function analyzeGit(options: GitOptions, requestOptions?: RequestOptions): Promise<IGitBundle> {
-  const analysisOptions: AnalyzeGitOptions = { ...analyzeGitDefaults, ...options };
+  const analysisOptions: AnalyzeGitOptions = { ...ANALYSIS_OPTIONS_DEFAULTS, ...options };
   const { baseURL, sessionToken, oAuthToken, username, includeLint, reachability, severity, gitUri, sarif, source } =
     analysisOptions;
   const bundleResponse = await createGitBundle(
@@ -447,29 +439,22 @@ export async function analyzeGit(options: GitOptions, requestOptions?: RequestOp
   return result;
 }
 
-interface CreateBundleFromFolders extends FolderOptions {
+interface CreateBundleFromFoldersOptions extends FolderOptions {
   supportedFiles?: ISupportedFiles;
   baseDir?: string;
   fileIgnores?: string[];
 }
 
-let createBundleFromFoldersDefaults = {
-  baseURL: defaultBaseURL,
-  sessionToken: '',
-  symlinksEnabled: false,
-  maxPayload: MAX_PAYLOAD,
-  defaultFileIgnores: IGNORES_DEFAULT,
-  source: '',
-};
+
 
 /**
  * Creates a remote bundle and returns response from the bundle API
  *
- * @param {CreateBundleFromFolders} options
+ * @param {CreateBundleFromFoldersOptions} options
  * @returns {Promise<RemoteBundle | null>}
  */
-export async function createBundleFromFolders(options: CreateBundleFromFolders): Promise<RemoteBundle | null> {
-  const analysisOptions = { ...createBundleFromFoldersDefaults, ...options };
+export async function createBundleFromFolders(options: CreateBundleFromFoldersOptions): Promise<RemoteBundle | null> {
+  const analysisOptions = { ...ANALYSIS_OPTIONS_DEFAULTS, ...options };
 
   const {
     baseURL,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { analyzeFolders, extendAnalysis, analyzeGit } from './analysis';
+import { analyzeFolders, extendAnalysis, analyzeGit, createBundleFromFolders } from './analysis';
 import emitter from './emitter';
 import { startSession, checkSession, reportEvent, reportError } from './http';
 import * as constants from './constants';
@@ -21,6 +21,7 @@ import {
 export {
   getGlobPatterns,
   analyzeFolders,
+  createBundleFromFolders,
   extendAnalysis,
   analyzeGit,
   startSession,

--- a/tests/analysis.spec.ts
+++ b/tests/analysis.spec.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import jsonschema from 'jsonschema';
 
-import { analyzeFolders } from '../src/analysis';
+import { analyzeFolders, createBundleFromFolders } from '../src/analysis';
 import { uploadRemoteBundle } from '../src/bundles';
 import { baseURL, sessionToken, TEST_TIMEOUT } from './constants/base';
 import { sampleProjectPath, bundleFiles, bundleFilesFull } from './constants/sample';
@@ -12,156 +12,188 @@ import { AnalysisSeverity } from '../src/interfaces/analysis-result.interface';
 import * as sarifSchema from './sarif-schema-2.1.0.json';
 
 describe('Functional test of analysis', () => {
-  it(
-    'analyze folder',
-    async () => {
-      const onSupportedFilesLoaded = jest.fn((data: ISupportedFiles | null) => {
-        if (data === null) {
-          // all good
-        }
-      });
-      emitter.on(emitter.events.supportedFilesLoaded, onSupportedFilesLoaded);
+  describe('analyzeFolders', () => {
+    it(
+      'analyze folder',
+      async () => {
+        const onSupportedFilesLoaded = jest.fn((data: ISupportedFiles | null) => {
+          if (data === null) {
+            // all good
+          }
+        });
+        emitter.on(emitter.events.supportedFilesLoaded, onSupportedFilesLoaded);
 
-      const bFiles = await bundleFilesFull;
-      const onScanFilesProgress = jest.fn((processed: number) => {
-        expect(typeof processed).toBe('number');
-        expect(processed).toBeGreaterThanOrEqual(0);
-        expect(processed).toBeLessThanOrEqual(bFiles.length);
-      });
-      emitter.on(emitter.events.scanFilesProgress, onScanFilesProgress);
+        const bFiles = await bundleFilesFull;
+        const onScanFilesProgress = jest.fn((processed: number) => {
+          expect(typeof processed).toBe('number');
+          expect(processed).toBeGreaterThanOrEqual(0);
+          expect(processed).toBeLessThanOrEqual(bFiles.length);
+        });
+        emitter.on(emitter.events.scanFilesProgress, onScanFilesProgress);
 
-      const onCreateBundleProgress = jest.fn((processed: number, total: number) => {
-        expect(typeof processed).toBe('number');
-        expect(total).toEqual(2);
+        const onCreateBundleProgress = jest.fn((processed: number, total: number) => {
+          expect(typeof processed).toBe('number');
+          expect(total).toEqual(2);
 
-        expect(processed).toBeLessThanOrEqual(total);
-      });
-      emitter.on(emitter.events.createBundleProgress, onCreateBundleProgress);
+          expect(processed).toBeLessThanOrEqual(total);
+        });
+        emitter.on(emitter.events.createBundleProgress, onCreateBundleProgress);
 
-      const onAnalyseProgress = jest.fn((data: AnalysisResponseProgress) => {
-        expect(['WAITING', 'FETCHING', 'ANALYZING', 'DC_DONE']).toContain(data.status);
-        expect(typeof data.progress).toBe('number');
-        expect(data.progress).toBeGreaterThanOrEqual(0);
-        expect(data.progress).toBeLessThanOrEqual(100);
-      });
-      emitter.on(emitter.events.analyseProgress, onAnalyseProgress);
+        const onAnalyseProgress = jest.fn((data: AnalysisResponseProgress) => {
+          expect(['WAITING', 'FETCHING', 'ANALYZING', 'DC_DONE']).toContain(data.status);
+          expect(typeof data.progress).toBe('number');
+          expect(data.progress).toBeGreaterThanOrEqual(0);
+          expect(data.progress).toBeLessThanOrEqual(100);
+        });
+        emitter.on(emitter.events.analyseProgress, onAnalyseProgress);
 
-      const onAPIRequestLog = jest.fn((message: string) => {
-        expect(typeof message).toBe('string');
-      });
-      emitter.on(emitter.events.apiRequestLog, onAPIRequestLog);
+        const onAPIRequestLog = jest.fn((message: string) => {
+          expect(typeof message).toBe('string');
+        });
+        emitter.on(emitter.events.apiRequestLog, onAPIRequestLog);
+
+        const bundle = await analyzeFolders({
+          baseURL,
+          sessionToken,
+          includeLint: false,
+          severity: 1,
+          paths: [sampleProjectPath],
+          symlinksEnabled: false,
+          maxPayload: 1000,
+        });
+        expect(bundle).toHaveProperty('baseURL');
+        expect(bundle).toHaveProperty('sessionToken');
+        expect(bundle).toHaveProperty('supportedFiles');
+        expect(bundle).toHaveProperty('analysisURL');
+        expect(Object.keys(bundle.analysisResults.files).length).toEqual(4);
+        expect(
+          bundle.analysisResults.files.hasOwnProperty(`${sampleProjectPath}/GitHubAccessTokenScrambler12.java`),
+        ).toBeTruthy();
+        expect(Object.keys(bundle.analysisResults.suggestions).length).toEqual(6);
+
+        expect(bundle.analysisResults.timing.analysis).toBeGreaterThanOrEqual(
+          bundle.analysisResults.timing.fetchingCode,
+        );
+        expect(bundle.analysisResults.timing.queue).toBeGreaterThanOrEqual(0);
+        expect(new Set(bundle.analysisResults.coverage)).toEqual(
+          new Set([
+            {
+              files: 2,
+              isSupported: true,
+              lang: 'Java',
+            },
+            {
+              files: 4,
+              isSupported: true,
+              lang: 'JavaScript',
+            },
+          ]),
+        );
+
+        // Check if emitter event happened
+        expect(onSupportedFilesLoaded).toHaveBeenCalledTimes(2);
+        expect(onScanFilesProgress).toHaveBeenCalledTimes(7);
+        expect(onCreateBundleProgress).toHaveBeenCalledTimes(3);
+        expect(onAnalyseProgress).toHaveBeenCalled();
+        expect(onAPIRequestLog).toHaveBeenCalled();
+
+        // Test uploadRemoteBundle with empty list of files
+        let uploaded = await uploadRemoteBundle(baseURL, sessionToken, bundle.bundleId, []);
+        // We do nothing in such cases
+        expect(uploaded).toEqual(true);
+
+        const onUploadBundleProgress = jest.fn((processed: number, total: number) => {
+          expect(typeof processed).toBe('number');
+          expect(total).toEqual(bFiles.length);
+
+          expect(processed).toBeLessThanOrEqual(total);
+        });
+        emitter.on(emitter.events.uploadBundleProgress, onUploadBundleProgress);
+
+        // Forse uploading files one more time
+        uploaded = await uploadRemoteBundle(baseURL, sessionToken, bundle.bundleId, bFiles);
+
+        expect(uploaded).toEqual(true);
+
+        expect(onUploadBundleProgress).toHaveBeenCalledTimes(2);
+        expect(onAPIRequestLog).toHaveBeenCalled();
+      },
+      TEST_TIMEOUT,
+    );
+
+    it('analyze folder - with sarif returned', async () => {
+      const includeLint = false;
+      const severity = AnalysisSeverity.info;
+      const paths: string[] = [path.join(sampleProjectPath, 'only_text')];
+      const symlinksEnabled = false;
+      const maxPayload = 1000;
+      const defaultFileIgnores = undefined;
+      const sarif = true;
 
       const bundle = await analyzeFolders({
         baseURL,
         sessionToken,
-        includeLint: false,
-        severity: 1,
-        paths: [sampleProjectPath],
-        symlinksEnabled: false,
-        maxPayload: 1000,
+        includeLint,
+        severity,
+        paths,
+        symlinksEnabled,
+        maxPayload,
+        defaultFileIgnores,
+        sarif,
       });
-      expect(bundle).toHaveProperty('baseURL');
-      expect(bundle).toHaveProperty('sessionToken');
-      expect(bundle).toHaveProperty('supportedFiles');
-      expect(bundle).toHaveProperty('analysisURL');
-      expect(Object.keys(bundle.analysisResults.files).length).toEqual(4);
-      expect(
-        bundle.analysisResults.files.hasOwnProperty(`${sampleProjectPath}/GitHubAccessTokenScrambler12.java`),
-      ).toBeTruthy();
-      expect(Object.keys(bundle.analysisResults.suggestions).length).toEqual(6);
+      const validationResult = jsonschema.validate(bundle.sarifResults, sarifSchema);
 
-      expect(bundle.analysisResults.timing.analysis).toBeGreaterThanOrEqual(bundle.analysisResults.timing.fetchingCode);
-      expect(bundle.analysisResults.timing.queue).toBeGreaterThanOrEqual(0);
-      expect(new Set(bundle.analysisResults.coverage)).toEqual(
-        new Set([
-          {
-            files: 2,
-            isSupported: true,
-            lang: 'Java',
-          },
-          {
-            files: 4,
-            isSupported: true,
-            lang: 'JavaScript',
-          },
-        ]),
-      );
-
-      // Check if emitter event happened
-      expect(onSupportedFilesLoaded).toHaveBeenCalledTimes(2);
-      expect(onScanFilesProgress).toHaveBeenCalledTimes(7);
-      expect(onCreateBundleProgress).toHaveBeenCalledTimes(3);
-      expect(onAnalyseProgress).toHaveBeenCalled();
-      expect(onAPIRequestLog).toHaveBeenCalled();
-
-      // Test uploadRemoteBundle with empty list of files
-      let uploaded = await uploadRemoteBundle(baseURL, sessionToken, bundle.bundleId, []);
-      // We do nothing in such cases
-      expect(uploaded).toEqual(true);
-
-      const onUploadBundleProgress = jest.fn((processed: number, total: number) => {
-        expect(typeof processed).toBe('number');
-        expect(total).toEqual(bFiles.length);
-
-        expect(processed).toBeLessThanOrEqual(total);
-      });
-      emitter.on(emitter.events.uploadBundleProgress, onUploadBundleProgress);
-
-      // Forse uploading files one more time
-      uploaded = await uploadRemoteBundle(baseURL, sessionToken, bundle.bundleId, bFiles);
-
-      expect(uploaded).toEqual(true);
-
-      expect(onUploadBundleProgress).toHaveBeenCalledTimes(2);
-      expect(onAPIRequestLog).toHaveBeenCalled();
-    },
-    TEST_TIMEOUT,
-  );
-
-  it('analyze folder - with sarif returned', async () => {
-    const includeLint = false;
-    const severity = AnalysisSeverity.info;
-    const paths: string[] = [path.join(sampleProjectPath, 'only_text')];
-    const symlinksEnabled = false;
-    const maxPayload = 1000;
-    const defaultFileIgnores = undefined;
-    const sarif = true;
-
-    const bundle = await analyzeFolders({
-      baseURL,
-      sessionToken,
-      includeLint,
-      severity,
-      paths,
-      symlinksEnabled,
-      maxPayload,
-      defaultFileIgnores,
-      sarif,
+      expect(validationResult.errors.length).toEqual(0);
     });
-    const validationResult = jsonschema.validate(bundle.sarifResults, sarifSchema);
 
-    expect(validationResult.errors.length).toEqual(0);
+    it('analyze empty folder', async () => {
+      const includeLint = false;
+      const severity = AnalysisSeverity.info;
+      const paths: string[] = [path.join(sampleProjectPath, 'only_text')];
+      const symlinksEnabled = false;
+      const maxPayload = 1000;
+
+      const bundle = await analyzeFolders({
+        baseURL,
+        sessionToken,
+        includeLint,
+        severity,
+        paths,
+        symlinksEnabled,
+        maxPayload,
+      });
+
+      expect(bundle.analysisResults.files).toEqual({});
+      expect(bundle.analysisResults.suggestions).toEqual({});
+      expect(bundle.analysisResults.coverage).toEqual([]);
+    });
   });
 
-  it('analyze empty folder', async () => {
-    const includeLint = false;
-    const severity = AnalysisSeverity.info;
-    const paths: string[] = [path.join(sampleProjectPath, 'only_text')];
-    const symlinksEnabled = false;
-    const maxPayload = 1000;
+  describe('createBundleFromFolders', () => {
+    it('should return a bundle with correct parameters', async () => {
+      const includeLint = false;
+      const severity = AnalysisSeverity.info;
+      const paths: string[] = [path.join(sampleProjectPath)];
+      const symlinksEnabled = false;
+      const maxPayload = 1000;
+      const defaultFileIgnores = undefined;
 
-    const bundle = await analyzeFolders({
-      baseURL,
-      sessionToken,
-      includeLint,
-      severity,
-      paths,
-      symlinksEnabled,
-      maxPayload,
+      const result = await createBundleFromFolders({
+        baseURL,
+        sessionToken,
+        includeLint,
+        severity,
+        paths,
+        symlinksEnabled,
+        maxPayload,
+        defaultFileIgnores,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveProperty("bundleId");
+      expect(result).toHaveProperty("missingFiles");
+      expect(result).toHaveProperty("uploadURL");
+
     });
-
-    expect(bundle.analysisResults.files).toEqual({});
-    expect(bundle.analysisResults.suggestions).toEqual({});
-    expect(bundle.analysisResults.coverage).toEqual([]);
   });
 });


### PR DESCRIPTION
- [x] Write separately for the new method. It should be covered by `analyzeFolders` tests.

#### What does this PR do?

Exposes `createBundleFromFolders` method which creates a bundle remotely and returns `bundleId`. The logic is extracted and reused (with some caveats) in the `analyzeFolders` method.

#### Where should the reviewer start?
\-
#### How should this be manually tested?
\-
#### Any background context you want to provide?

This is being done to allow us to separate logic which uploads and which analyses so that we can perform this in separate steps.