### PR TITLE
fix: removed deprecated @types/multimatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@types/lodash.chunk": "^4.2.6",
     "@types/lodash.omit": "^4.5.6",
     "@types/lodash.union": "^4.6.6",
-    "@types/multimatch": "^4.0.0",
     "@types/sarif": "^2.1.3",
     "@types/uuid": "^8.3.0",
     "axios": "^0.21.1",


### PR DESCRIPTION
- [x] Ready for review
- [ ] Linked to Jira ticket
Solves `npm WARN deprecated @types/multimatch@4.0.0: This is a stub types definition. multimatch provides its own type definitions, so you do not need this installed.`
as requested here:
https://snyk.slack.com/archives/C01DGQ3AT09/p1623147347346700
