### PR TITLE
fix: temporary change of semantic-release release ver. latest version is broken

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,8 @@ jobs:
           command: npm install
       - run:
           name: Publish to GitHub
-          command: npx semantic-release
+          ## this is a work around, as it seems that the latest version has issues with < node14
+          command: npx semantic-release@16
 
 workflows:
   default_workflow:


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Linked to Jira ticket

#### What does this PR do?

Latest sematic release package doesn't work with node12. until it gets fixed, we want to downgrade it to a version that was suggest as working

the current issue 
```
npx: installed 573 in 13.448s
/home/circleci/.npm/_npx/86/lib/node_modules/semantic-release/node_modules/marked/src/marked.js:158
          const prevRenderer = extensions.renderers?.[ext.name];
                                                    ^

SyntaxError: Unexpected token '.'
    at wrapSafe (internal/modules/cjs/loader.js:915:16)
    at Module._compile (internal/modules/cjs/loader.js:963:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/home/circleci/.npm/_npx/86/lib/node_modules/semantic-release/index.js:2:16)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)

```

suggested solution: https://github.com/semantic-release/semantic-release/issues/1981 
#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
