### PR TITLE
fix: resolve relative bundle file path correctly [ROAD-329]

### DIFF
--- a/src/files.ts
+++ b/src/files.ts
@@ -350,7 +350,7 @@ export async function prepareExtendingBundle(
   };
 }
 
-function getBundleFilePath(filePath: string, baseDir: string) {
+export function getBundleFilePath(filePath: string, baseDir: string) {
   const relPath = baseDir ? nodePath.relative(baseDir, filePath) : filePath; // relPath without explicit base makes no sense
   const posixPath = !isWindows ? relPath : relPath.replace(/\\/g, '/');
   return encodeURI(posixPath);

--- a/tests/files.spec.ts
+++ b/tests/files.spec.ts
@@ -8,6 +8,7 @@ import {
   composeFilePayloads,
   parseFileIgnores,
   getFileInfo,
+  getBundleFilePath,
 } from '../src/files';
 
 import { sampleProjectPath, supportedFiles, bundleFiles, bundleFilesFull, bundleFileIgnores } from './constants/sample';
@@ -113,4 +114,16 @@ describe('files', () => {
     const fileMeta = await getFileInfo(filePath, sampleProjectPath);
     expect(fileMeta?.hash).toEqual('3e2979852cc2e97f48f7e7973a8b0837eb73ed0485c868176bc3aa58c499f534');
   });
+
+  it('obtains correct bundle file path if no baseDir specified', () => {
+    const baseDir = '';
+    const darwinPath = '/Users/user/Git/goof/routes/index.js';
+    expect(getBundleFilePath(darwinPath, baseDir)).toEqual(darwinPath);
+
+    const linuxPath = '/home/user/Git/goof/routes/index.js';
+    expect(getBundleFilePath(linuxPath, baseDir)).toEqual(linuxPath);
+
+    const windowsPath = 'C:\\Users\\user\\Git\\goof\\index.js';
+    expect(getBundleFilePath(windowsPath, baseDir)).toEqual(encodeURI(windowsPath));
+  })
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Linked to Jira ticket

#### What does this PR do?
This PR resolves the issue of determining relative bundle file paths when many folders are passed for the analysis.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?
When `getBundleFilePath()` is called for multiple folders analysis (e.g. VS Code workspace with many folders), it is passed with `baseDir = ''` argument that makes relative path resolution fail on Linux within VS Code extension currently.

The following behaviour is observed at the moment:
args: `baseDir='', filePath='/home/user/Downloads/goof-master/routes/index.js'`
returns: `'Downloads/goof-master/routes/index.js'`

`path.relative()` relies on `process.cwd()` that can be different based on where Node.js process was started. For VS Code, If this code is called on Mac OS, `process.cwd()` defaults to `/`, however Linux defaults to the user directory e.g. `/home/user`. Thus wrong analysis results file paths for bundles will be returned. 

Relevant Jira ticket: https://snyksec.atlassian.net/browse/ROAD-329

#### Screenshots


#### Additional questions
