### PR TITLE
fix: considering customers lang support NEBULA-174

### DIFF
--- a/src/lang-map.d.ts
+++ b/src/lang-map.d.ts
@@ -1,0 +1,6 @@
+declare module 'lang-map';
+interface LangMap {
+  extensions: (s: string) => string[] | undefined;
+  languages: (s: string) => string[] | undefined;
+}
+declare const langMap: LangMap;

--- a/tests/bundle.spec.ts
+++ b/tests/bundle.spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { createBundleFromFolders } from '../src/bundles';
+import { createBundleFromFolders, convertLanguagesToExtensions } from '../src/bundles';
 import { baseURL, sessionToken, source } from './constants/base';
 import { sampleProjectPath } from './constants/sample';
 
@@ -22,5 +22,65 @@ describe('Functional test for bundle creation', () => {
     expect(result).not.toBeNull();
     expect(result).toHaveProperty('bundleHash');
     expect(result).toHaveProperty('missingFiles');
+  });
+
+  it('should return list of supported files based on customers settings', async () => {
+    const paths: string[] = [path.join(sampleProjectPath)];
+    const symlinksEnabled = false;
+    const defaultFileIgnores = undefined;
+
+    const result = await createBundleFromFolders({
+      baseURL,
+      sessionToken,
+      source,
+      paths,
+      symlinksEnabled,
+      defaultFileIgnores,
+      customerLanguages: ['javascript'],
+    });
+
+    expect(result && result.supportedFiles.extensions).toEqual(['.js', '.es6', '.jsx']);
+  });
+
+  it('Converts code language name to file extensions, extensions as provided by deepcode backend', async () => {
+    const extensions = convertLanguagesToExtensions([
+      'javascript',
+      'java',
+      'python',
+      'csharp',
+      'php',
+      'ruby',
+      'go',
+      'cpp',
+      'c',
+      'swift',
+    ]);
+
+    const jsExt = ['.js', '.es6', '.jsx'];
+    const javaExt = ['.java'];
+    const pythonExt = ['.py'];
+    const cSharpExt = ['.cs'];
+    const phpExt = ['.php'];
+    const rubyExt = ['.rb'];
+    const goExt = ['.go'];
+    const cppExt = ['.cc', '.cpp', '.cxx', '.hpp'];
+    const cExt = ['.c', '.h'];
+    const swiftExt = ['.swift'];
+
+    expect(extensions).toEqual(
+      expect.arrayContaining([
+        ...jsExt,
+        ...javaExt,
+        ...pythonExt,
+        ...cSharpExt,
+        ...phpExt,
+        ...rubyExt,
+        ...goExt,
+        ...cExt,
+        ...cppExt,
+        ...cSharpExt,
+        ...swiftExt,
+      ]),
+    );
   });
 });


### PR DESCRIPTION
#### What does this PR do?

Certain customers do not have all code languages enabled. Currently, the code-client only checks supported languages from (DC) system. This is not enough, because if for an example, C and C++ are not enabled for a given customer and those 2 languages are supported by DC system, we would scan files for the mentioned languages. This PR solves this issue.

The above issue is reproducible by the customer of code-client -- Code Agent

Jira: https://snyksec.atlassian.net/jira/software/c/projects/NEBULA/boards/282?modal=detail&selectedIssue=NEBULA-174