### PR TITLE
fix: getIpFamily - do not expect specific error for clients without IPv6

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,7 +48,6 @@ export const NETWORK_ERRORS = {
   ECONNRESET: ErrorCodes.connectionRefused,
   ENETUNREACH: ErrorCodes.connectionRefused,
   ENOTFOUND: ErrorCodes.dnsNotFound,
-  EADDRNOTAVAIL: ErrorCodes.dnsNotFound, // happens when DNS cannot resolve the IPv6
 };
 
 export const DEFAULT_ERROR_MESSAGES: { [P in ErrorCodes]: string } = {

--- a/src/http.ts
+++ b/src/http.ts
@@ -100,7 +100,7 @@ export async function getIpFamily(authHost: string): Promise<IpFamily> {
     0,
   );
 
-  const ipv6Incompatible = (<FailedResponse>res).errorCode === ErrorCodes.dnsNotFound;
+  const ipv6Incompatible = (<FailedResponse>res).error;
 
   return ipv6Incompatible ? undefined : family;
 }

--- a/tests/analysis.spec.ts
+++ b/tests/analysis.spec.ts
@@ -248,7 +248,7 @@ describe('Functional test of analysis', () => {
 
         const sarifResults = extendedBundle.analysisResults.sarif;
 
-        expect(sarifResults.runs[0].tool.driver.rules).toHaveLength(7);
+        expect(sarifResults.runs[0].tool.driver.rules).toHaveLength(8);
         expect(sarifResults.runs[0].results).toHaveLength(15);
         const getRes = (path: string) =>
           sarifResults.runs[0].results!.find(

--- a/tests/http.spec.ts
+++ b/tests/http.spec.ts
@@ -1,0 +1,33 @@
+import needle from 'needle';
+
+describe('HTTP', () => {
+  const authHost = 'https://dev.snyk.io';
+
+  beforeEach(() => {
+    jest.resetModuleRegistry();
+  })
+
+  it('should respolve IPv6, if http request succeeds', async () => {
+    jest.mock('needle', () => jest.fn(() => ({
+      response: {
+        statusCode: 401,
+        body: {}
+      }
+    })));
+
+    const http = await import('../src');
+    const family = await http.getIpFamily(authHost);
+
+    expect(family).toBe(6);
+  });
+
+  it('shouldn not resolve IPv6, if http request throws an error', async () => {
+    const errorFn = () => { throw new Error(); };
+    jest.mock('needle', () => jest.fn(errorFn));
+
+    const http = await import('../src');
+    const family = await http.getIpFamily(authHost);
+
+    expect(family).toBe(undefined);
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Linked to Jira ticket - https://snyksec.atlassian.net/browse/ROAD-643

#### What does this PR do?
This PR is a replacement for [previous PR](https://github.com/snyk/code-client/pull/119) to fix the regression for IPv6 clients. We've noticed that some of the clients who don't have full IPv6 supports started to authenticate using IPv6 which broke their VS Code extension.

Some users encountered ENETUNREACH error instead of EADDRNOTAVAIL as wrongly assumed in the previous fix PR. Thus we shouldn't rely on specific error, rather on an error. This is how it was before the refactoring around http took place and is consistent with Snyk CLI code.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?
This fixes the following issues:
https://snyk.slack.com/archives/C026PS65XA8/p1642092098003500
https://snyk.slack.com/archives/C01FA88CUU9/p1641979366003300?thread_ts=1641978929.003100&cid=C01FA88CUU9
https://github.com/snyk/vscode-extension/issues/132 🤞 

#### Screenshots


#### Additional questions
