### PR TITLE
fix: glob matching in extending bundle on Windows [ROAD-650]

### DIFF
--- a/src/files.ts
+++ b/src/files.ts
@@ -302,6 +302,10 @@ export async function prepareExtendingBundle(
 
   if (processingFiles.length) {
     // Determine existing files (minus removed)
+    if (isWindows) {
+      processingFiles = processingFiles.map(f => f.replace(/\\/g, '/')); // fg requires forward-slashes in Windows globs
+    }
+
     const entries = await fg(processingFiles, {
       ...fgOptions,
       cwd: baseDir,


### PR DESCRIPTION
- [x] Ready for review
- [x] Linked to Jira ticket - https://snyksec.atlassian.net/browse/ROAD-650

#### What does this PR do?
Glob determines changed files as removed, when bundle gets extended currently on Windows environments.

The problem arises due to a use of backslashes when passing glob pattern to fast-glob library. As [fast-glob documentation states](https://github.com/snyk/fast-glob#how-to-write-patterns-on-windows), forward slashes should be used instead on Win environments.

It would be great to run automates tests on Windows environment to pick up those type of issues in future. I expect "extend bundle files" test should pick the problem up, when tested under Windows.


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
