### PR TITLE
test: remove precise length for results

### DIFF
--- a/tests/analysis.spec.ts
+++ b/tests/analysis.spec.ts
@@ -163,8 +163,8 @@ describe('Functional test of analysis', () => {
       expect(bundle.analysisResults.type === 'legacy').toBeTruthy();
       if (bundle.analysisResults.type !== 'legacy') return;
 
-      expect(Object.keys(bundle.analysisResults.files)).toHaveLength(5);
-      expect(Object.keys(bundle.analysisResults.suggestions)).toHaveLength(11);
+      expect(Object.keys(bundle.analysisResults.files).length).toBeGreaterThan(0);
+      expect(Object.keys(bundle.analysisResults.suggestions).length).toBeGreaterThan(0);
     });
 
     it('analyze folder - with sarif returned', async () => {
@@ -222,8 +222,8 @@ describe('Functional test of analysis', () => {
         expect(fileAnalysis.analysisResults.type === 'sarif').toBeTruthy();
         if (fileAnalysis.analysisResults.type !== 'sarif') return;
 
-        expect(fileAnalysis.analysisResults.sarif.runs[0].tool.driver.rules).toHaveLength(10);
-        expect(fileAnalysis.analysisResults.sarif.runs[0].results).toHaveLength(17);
+        expect(fileAnalysis.analysisResults.sarif.runs[0].tool.driver.rules?.length).toBeGreaterThan(0);
+        expect(fileAnalysis.analysisResults.sarif.runs[0].results?.length).toBeGreaterThan(0);
 
         const extender = await bundleExtender();
         type Awaited<T> = T extends PromiseLike<infer U> ? Awaited<U> : T;
@@ -248,8 +248,8 @@ describe('Functional test of analysis', () => {
 
         const sarifResults = extendedBundle.analysisResults.sarif;
 
-        expect(sarifResults.runs[0].tool.driver.rules).toHaveLength(8);
-        expect(sarifResults.runs[0].results).toHaveLength(15);
+        expect(sarifResults.runs[0].tool.driver.rules?.length).toBeGreaterThan(0);
+        expect(sarifResults.runs[0].results?.length).toBeGreaterThan(0);
         const getRes = (path: string) =>
           sarifResults.runs[0].results!.find(
             res => res.locations?.[0].physicalLocation?.artifactLocation?.uri === path,


### PR DESCRIPTION
Here we don't really care about the length of results and having a set
number for amount of issues makes this test prone to flakiness.  We are more
interested whether the bundle was extended properly.
