### PR TITLE
fix: bundle file path resolution for paths with whitespace [ROAD-637]

### DIFF
--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -83,14 +83,11 @@ export async function analyzeBundle(options: GetAnalysisOptions): Promise<Analys
 }
 
 function normalizeResultFiles(files: AnalysisFiles, baseDir: string): AnalysisFiles {
-  if (baseDir) {
-    return Object.entries(files).reduce((obj, [path, positions]) => {
-      const filePath = resolveBundleFilePath(baseDir, path);
-      obj[filePath] = positions;
-      return obj;
-    }, {});
-  }
-  return files;
+  return Object.entries(files).reduce((obj, [path, positions]) => {
+    const filePath = resolveBundleFilePath(baseDir, path);
+    obj[filePath] = positions;
+    return obj;
+  }, {});
 }
 
 export async function analyzeFolders(options: FileAnalysisOptions): Promise<FileAnalysis | null> {

--- a/src/files.ts
+++ b/src/files.ts
@@ -422,7 +422,11 @@ export function resolveBundleFilePath(baseDir: string, bundleFilePath: string): 
     relPath = relPath.replace(/\//g, '\\');
   }
 
-  return nodePath.resolve(baseDir, decodeURI(relPath));
+  if (baseDir) {
+    return nodePath.resolve(baseDir, decodeURI(relPath));
+  }
+
+  return decodeURI(relPath);
 }
 
 export function* composeFilePayloads(files: FileInfo[], bucketSize = MAX_PAYLOAD): Generator<FileInfo[]> {

--- a/tests/files.spec.ts
+++ b/tests/files.spec.ts
@@ -9,6 +9,7 @@ import {
   parseFileIgnores,
   getFileInfo,
   getBundleFilePath,
+  resolveBundleFilePath,
 } from '../src/files';
 
 import { sampleProjectPath, supportedFiles, bundleFiles, bundleFilesFull, bundleFileIgnores } from './constants/sample';
@@ -116,7 +117,7 @@ describe('files', () => {
     expect(fileMeta?.hash).toEqual('3e2979852cc2e97f48f7e7973a8b0837eb73ed0485c868176bc3aa58c499f534');
   });
 
-  it('obtains correct bundle file path if no baseDir specified', () => {
+  it('gets correct bundle file path if no baseDir specified', () => {
     const baseDir = '';
     const darwinPath = '/Users/user/Git/goof/routes/index.js';
     expect(getBundleFilePath(darwinPath, baseDir)).toEqual(darwinPath);
@@ -126,5 +127,17 @@ describe('files', () => {
 
     const windowsPath = 'C:\\Users\\user\\Git\\goof\\index.js';
     expect(getBundleFilePath(windowsPath, baseDir)).toEqual(encodeURI(windowsPath));
+  });
+
+  it('resolves correct bundle file path if no baseDir specified and contains whitespace', () => {
+    const baseDir = '';
+    const darwinPath = '/Users/user/Git/goof%20test/routes/index.js';
+    expect(resolveBundleFilePath(baseDir, darwinPath)).toEqual(decodeURI(darwinPath));
+
+    const linuxPath = '/home/user/Git/goof%20test/routes/index.js';
+    expect(resolveBundleFilePath(baseDir, linuxPath)).toEqual(decodeURI(linuxPath));
+
+    const windowsPath = 'C:\\Users\\user\\Git\\goof%20test\\index.js';
+    expect(resolveBundleFilePath(baseDir, windowsPath)).toEqual(decodeURI(windowsPath));
   });
 });


### PR DESCRIPTION
- [ ] Ready for review
- [x] Linked to Jira ticket

#### What does this PR do?
This PR addresses https://github.com/snyk/vscode-extension/issues/165 and https://github.com/snyk/vscode-extension/issues/114 respectively, where file navigation breaks when Snyk Code analysis is run in workspace (multi-folder) mode.

If multiple folders are passed for analysis, [`baseDir` gets set to empty string](https://github.com/snyk/code-client/blob/a8c8b58ab5da76663347f1ebdb3b86623459b6c2/src/files.ts#L177). It [skips result file paths normalisation](https://github.com/snyk/code-client/compare/fix/workspace-resolveBundleFilePath?expand=1#diff-e369c18a244b57d8ee4a1bdcabbea4cf17a6086c6f140efb494b125fa911c5a2L85), leading to encoded path provided back to the analysis issuer (VS Code extension in this case). VSCE doesn't do any file normalisation since relying on `code-client`, thus breaking file navigation for our end users. 

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?


#### Screenshots

#### Additional questions
