### PR TITLE
chore: Transferring ownership to Zenith NEBULA-492

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 # Snyk Code will be required for a review on every PR
 
-*  @snyk/nebula
+*  @snyk/zenith
+


### PR DESCRIPTION
Zenith doesn't seem to have their Github org setup correctly yet, removing Nebula's ownership