### PR TITLE
feat: Support Base64 encoding

### DIFF
--- a/src/bundles.ts
+++ b/src/bundles.ts
@@ -47,7 +47,7 @@ async function* prepareRemoteBundle(
   emitter.createBundleProgress(cumulativeProgress, options.files.length);
   for (const chunkedFiles of composeFilePayloads(options.files, MAX_PAYLOAD)) {
     const apiParams = {
-      ...pick(options, ['baseURL', 'sessionToken', 'source', 'removedFiles', 'requestId']),
+      ...pick(options, ['baseURL', 'sessionToken', 'source', 'removedFiles', 'requestId', 'base64Encoding']),
       files: chunkedFiles.reduce((d, f) => {
         // deepcode ignore PrototypePollution: FP this is an internal code
         d[f.bundlePath] = f.hash;
@@ -91,7 +91,7 @@ interface UpdateRemoteBundleOptions extends ConnectionOptions {
 export async function uploadRemoteBundle(options: UpdateRemoteBundleOptions): Promise<void> {
   let uploadedFiles = 0;
   emitter.uploadBundleProgress(0, options.files.length);
-  const apiParams = pick(options, ['baseURL', 'sessionToken', 'source', 'bundleHash', 'requestId']);
+  const apiParams = pick(options, ['baseURL', 'sessionToken', 'source', 'bundleHash', 'requestId', 'base64Encoding']);
 
   const uploadFileChunks = async (bucketFiles: FileInfo[]): Promise<void> => {
     // Note: we specifically create __new__ isolated bundles here to faster files upload
@@ -129,7 +129,7 @@ async function fullfillRemoteBundle(options: FullfillRemoteBundleOptions): Promi
   // Check remove bundle to make sure no missing files left
   let attempts = 0;
   let { remoteBundle } = options;
-  const connectionOptions = pick(options, ['baseURL', 'sessionToken', 'source', 'requestId']);
+  const connectionOptions = pick(options, ['baseURL', 'sessionToken', 'source', 'requestId', 'base64Encoding']);
 
   while (remoteBundle.missingFiles.length && attempts < (options.maxAttempts || MAX_UPLOAD_ATTEMPTS)) {
     const missingFiles = await resolveBundleFiles(options.baseDir, remoteBundle.missingFiles);
@@ -156,7 +156,7 @@ interface RemoteBundleFactoryOptions extends PrepareRemoteBundleOptions {
 
 export async function remoteBundleFactory(options: RemoteBundleFactoryOptions): Promise<RemoteBundle | null> {
   let remoteBundle: RemoteBundle | null = null;
-  const baseOptions = pick(options, ['baseURL', 'sessionToken', 'source', 'baseDir', 'requestId']);
+  const baseOptions = pick(options, ['baseURL', 'sessionToken', 'source', 'baseDir', 'requestId', 'base64Encoding']);
   const bundleFactory = prepareRemoteBundle(omit(options, ['baseDir']));
   for await (const response of bundleFactory) {
     if (response.type === 'error') {
@@ -250,7 +250,7 @@ export async function createBundleFromFolders(options: CreateBundleFromFoldersOp
   }
 
   const bundleOptions = {
-    ...pick(options, ['baseURL', 'sessionToken', 'source', 'requestId']),
+    ...pick(options, ['baseURL', 'sessionToken', 'source', 'requestId', 'base64Encoding']),
     baseDir,
     files: bundleFiles,
   };

--- a/tests/analysis.spec.ts
+++ b/tests/analysis.spec.ts
@@ -52,7 +52,7 @@ describe('Functional test of analysis', () => {
         emitter.on(emitter.events.apiRequestLog, onAPIRequestLog);
 
         const bundle = await analyzeFolders({
-          connection: { baseURL, sessionToken, source },
+          connection: { baseURL, sessionToken, source, base64Encoding:false },
           analysisOptions: {
             severity: 1,
             prioritized: true,
@@ -119,6 +119,7 @@ describe('Functional test of analysis', () => {
           source,
           bundleHash: bundle.fileBundle.bundleHash,
           files: [],
+          base64Encoding: false
         });
 
         const onUploadBundleProgress = jest.fn((processed: number, total: number) => {
@@ -138,6 +139,7 @@ describe('Functional test of analysis', () => {
           source,
           bundleHash: bundle.fileBundle.bundleHash,
           files: bFiles.filter(({ bundlePath }) => !shouldNotBeInBundle.includes(bundlePath)),
+          base64Encoding: false,
         });
         expect(onUploadBundleProgress).toHaveBeenCalledTimes(2);
         expect(onAPIRequestLog).toHaveBeenCalled();
@@ -147,7 +149,7 @@ describe('Functional test of analysis', () => {
 
     it('analyze folder legacy json results', async () => {
       const bundle = await analyzeFolders({
-        connection: { baseURL, sessionToken, source },
+        connection: { baseURL, sessionToken, source, base64Encoding:false },
         analysisOptions: { severity: AnalysisSeverity.info, prioritized: true, legacy: true },
         fileOptions: {
           paths: [sampleProjectPath],
@@ -168,7 +170,7 @@ describe('Functional test of analysis', () => {
 
     it('analyze folder - with sarif returned', async () => {
       const bundle = await analyzeFolders({
-        connection: { baseURL, sessionToken, source },
+        connection: { baseURL, sessionToken, source, base64Encoding:false },
         analysisOptions: { severity: AnalysisSeverity.info, prioritized: true },
         fileOptions: {
           paths: [sampleProjectPath],
@@ -189,7 +191,7 @@ describe('Functional test of analysis', () => {
 
     it('analyze empty folder', async () => {
       const bundle = await analyzeFolders({
-        connection: { baseURL, sessionToken, source },
+        connection: { baseURL, sessionToken, source, base64Encoding:false },
         analysisOptions: { severity: AnalysisSeverity.info },
         fileOptions: {
           paths: [path.join(sampleProjectPath, 'only_text')],
@@ -205,7 +207,7 @@ describe('Functional test of analysis', () => {
       'extend folder analysis',
       async () => {
         const fileAnalysis = await analyzeFolders({
-          connection: { baseURL, sessionToken, source },
+          connection: { baseURL, sessionToken, source, base64Encoding:false },
           analysisOptions: {
             severity: 1,
           },
@@ -310,7 +312,7 @@ describe('Functional test of analysis', () => {
       const makeRequestSpy = jest.spyOn(needle, 'makeRequest');
 
       await analyzeFolders({
-        connection: { baseURL, sessionToken, source },
+        connection: { baseURL, sessionToken, source, base64Encoding:false },
         analysisOptions: {
           severity: 1,
         },

--- a/tests/analysis.spec.ts
+++ b/tests/analysis.spec.ts
@@ -52,7 +52,7 @@ describe('Functional test of analysis', () => {
         emitter.on(emitter.events.apiRequestLog, onAPIRequestLog);
 
         const bundle = await analyzeFolders({
-          connection: { baseURL, sessionToken, source, base64Encoding:false },
+          connection: { baseURL, sessionToken, source, base64Encoding: false },
           analysisOptions: {
             severity: 1,
             prioritized: true,
@@ -119,7 +119,7 @@ describe('Functional test of analysis', () => {
           source,
           bundleHash: bundle.fileBundle.bundleHash,
           files: [],
-          base64Encoding: false
+          base64Encoding: false,
         });
 
         const onUploadBundleProgress = jest.fn((processed: number, total: number) => {
@@ -149,7 +149,7 @@ describe('Functional test of analysis', () => {
 
     it('analyze folder legacy json results', async () => {
       const bundle = await analyzeFolders({
-        connection: { baseURL, sessionToken, source, base64Encoding:false },
+        connection: { baseURL, sessionToken, source, base64Encoding: false },
         analysisOptions: { severity: AnalysisSeverity.info, prioritized: true, legacy: true },
         fileOptions: {
           paths: [sampleProjectPath],
@@ -170,7 +170,7 @@ describe('Functional test of analysis', () => {
 
     it('analyze folder - with sarif returned', async () => {
       const bundle = await analyzeFolders({
-        connection: { baseURL, sessionToken, source, base64Encoding:false },
+        connection: { baseURL, sessionToken, source, base64Encoding: false },
         analysisOptions: { severity: AnalysisSeverity.info, prioritized: true },
         fileOptions: {
           paths: [sampleProjectPath],
@@ -191,7 +191,7 @@ describe('Functional test of analysis', () => {
 
     it('analyze empty folder', async () => {
       const bundle = await analyzeFolders({
-        connection: { baseURL, sessionToken, source, base64Encoding:false },
+        connection: { baseURL, sessionToken, source, base64Encoding: false },
         analysisOptions: { severity: AnalysisSeverity.info },
         fileOptions: {
           paths: [path.join(sampleProjectPath, 'only_text')],
@@ -207,7 +207,7 @@ describe('Functional test of analysis', () => {
       'extend folder analysis',
       async () => {
         const fileAnalysis = await analyzeFolders({
-          connection: { baseURL, sessionToken, source, base64Encoding:false },
+          connection: { baseURL, sessionToken, source, base64Encoding: false },
           analysisOptions: {
             severity: 1,
           },
@@ -312,7 +312,7 @@ describe('Functional test of analysis', () => {
       const makeRequestSpy = jest.spyOn(needle, 'makeRequest');
 
       await analyzeFolders({
-        connection: { baseURL, sessionToken, source, base64Encoding:false },
+        connection: { baseURL, sessionToken, source, base64Encoding: false },
         analysisOptions: {
           severity: 1,
         },

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -104,6 +104,7 @@ describe('Requests to public API', () => {
         sessionToken,
         files,
         source,
+        base64Encoding: false
       });
       expect(response.type).toEqual('success');
       if (response.type === 'error') {
@@ -125,6 +126,7 @@ describe('Requests to public API', () => {
         sessionToken,
         source,
         bundleHash: fakeBundleHashFull,
+        base64Encoding: false
       });
       expect(response.type).toEqual('success');
       if (response.type === 'error') return;
@@ -142,6 +144,7 @@ describe('Requests to public API', () => {
         sessionToken,
         source,
         bundleHash: 'mock-expired-bundle-id',
+        base64Encoding: false
       });
       expect(response.type).toEqual('error');
       // dummy to cheat typescript compiler
@@ -163,6 +166,7 @@ describe('Requests to public API', () => {
           bundleHash: fakeBundleHashFull,
           severity: 1,
           source,
+          base64Encoding: false
         });
       } while (response.type === 'success');
 
@@ -199,6 +203,7 @@ describe('Requests to public API', () => {
           `routes/index.js`,
           `routes/sharks.js`,
         ],
+        base64Encoding: false
       });
       expect(response.type).toEqual('success');
       if (response.type === 'error') return;
@@ -219,6 +224,7 @@ describe('Requests to public API', () => {
         files: {
           'new2.js': 'new1234',
         },
+        base64Encoding: false
       });
 
       expect(response.type).toEqual('error');
@@ -244,6 +250,7 @@ describe('Requests to public API', () => {
           'df.js': { hash: 'df', content: 'const module = new Module();' },
           'sdfs.js': { hash: 'sdfs', content: 'const App = new App();' },
         },
+        base64Encoding: false
       });
       expect(response.type).toEqual('success');
       if (response.type !== 'success') return; // TS trick
@@ -267,6 +274,7 @@ describe('Requests to public API', () => {
         sessionToken,
         source,
         files,
+        base64Encoding: false
       });
       expect(bundleResponse.type).toEqual('success');
       if (bundleResponse.type === 'error') return;
@@ -282,6 +290,7 @@ describe('Requests to public API', () => {
         sessionToken,
         source,
         bundleHash: realBundleHashFull,
+        base64Encoding: false
       });
       expect(checkResponse.type).toEqual('success');
       if (checkResponse.type === 'error') return;
@@ -295,6 +304,7 @@ describe('Requests to public API', () => {
         source,
         bundleHash: realBundleHashFull,
         severity: 1,
+        base64Encoding: false
       });
       expect(response.type).toEqual('success');
       if (response.type === 'error') return;
@@ -333,6 +343,7 @@ describe('Requests to public API', () => {
           severity: 1,
           limitToFiles: [`GitHubAccessTokenScrambler12.java`],
           source,
+          base64Encoding: false
         });
 
         expect(response.type).toEqual('success');
@@ -353,6 +364,7 @@ describe('Requests to public API', () => {
           bundleHash: realBundleHashFull,
           severity: 3,
           source,
+          base64Encoding: false
         });
         expect(response.type).toEqual('success');
         if (response.type === 'error') return;

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -104,7 +104,7 @@ describe('Requests to public API', () => {
         sessionToken,
         files,
         source,
-        base64Encoding: false
+        base64Encoding: false,
       });
       expect(response.type).toEqual('success');
       if (response.type === 'error') {
@@ -126,7 +126,7 @@ describe('Requests to public API', () => {
         sessionToken,
         source,
         bundleHash: fakeBundleHashFull,
-        base64Encoding: false
+        base64Encoding: false,
       });
       expect(response.type).toEqual('success');
       if (response.type === 'error') return;
@@ -144,7 +144,7 @@ describe('Requests to public API', () => {
         sessionToken,
         source,
         bundleHash: 'mock-expired-bundle-id',
-        base64Encoding: false
+        base64Encoding: false,
       });
       expect(response.type).toEqual('error');
       // dummy to cheat typescript compiler
@@ -166,7 +166,7 @@ describe('Requests to public API', () => {
           bundleHash: fakeBundleHashFull,
           severity: 1,
           source,
-          base64Encoding: false
+          base64Encoding: false,
         });
       } while (response.type === 'success');
 
@@ -203,7 +203,7 @@ describe('Requests to public API', () => {
           `routes/index.js`,
           `routes/sharks.js`,
         ],
-        base64Encoding: false
+        base64Encoding: false,
       });
       expect(response.type).toEqual('success');
       if (response.type === 'error') return;
@@ -224,7 +224,7 @@ describe('Requests to public API', () => {
         files: {
           'new2.js': 'new1234',
         },
-        base64Encoding: false
+        base64Encoding: false,
       });
 
       expect(response.type).toEqual('error');
@@ -250,7 +250,7 @@ describe('Requests to public API', () => {
           'df.js': { hash: 'df', content: 'const module = new Module();' },
           'sdfs.js': { hash: 'sdfs', content: 'const App = new App();' },
         },
-        base64Encoding: false
+        base64Encoding: false,
       });
       expect(response.type).toEqual('success');
       if (response.type !== 'success') return; // TS trick
@@ -274,7 +274,7 @@ describe('Requests to public API', () => {
         sessionToken,
         source,
         files,
-        base64Encoding: false
+        base64Encoding: false,
       });
       expect(bundleResponse.type).toEqual('success');
       if (bundleResponse.type === 'error') return;
@@ -290,7 +290,7 @@ describe('Requests to public API', () => {
         sessionToken,
         source,
         bundleHash: realBundleHashFull,
-        base64Encoding: false
+        base64Encoding: false,
       });
       expect(checkResponse.type).toEqual('success');
       if (checkResponse.type === 'error') return;
@@ -304,7 +304,7 @@ describe('Requests to public API', () => {
         source,
         bundleHash: realBundleHashFull,
         severity: 1,
-        base64Encoding: false
+        base64Encoding: false,
       });
       expect(response.type).toEqual('success');
       if (response.type === 'error') return;
@@ -343,7 +343,7 @@ describe('Requests to public API', () => {
           severity: 1,
           limitToFiles: [`GitHubAccessTokenScrambler12.java`],
           source,
-          base64Encoding: false
+          base64Encoding: false,
         });
 
         expect(response.type).toEqual('success');
@@ -364,7 +364,7 @@ describe('Requests to public API', () => {
           bundleHash: realBundleHashFull,
           severity: 3,
           source,
-          base64Encoding: false
+          base64Encoding: false,
         });
         expect(response.type).toEqual('success');
         if (response.type === 'error') return;

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -400,36 +400,15 @@ describe('Base64 encoded operations', () => {
     });
 
     const requestBody = makeRequestSpy.mock.calls[0][0].body as string;
-    expect(JSON.parse(Buffer.from(requestBody,'base64').toString())).toEqual(files);
+    expect(JSON.parse(Buffer.from(requestBody, 'base64').toString())).toEqual(files);
   }),
-
-  it('extends a base64-encoded bundle', async() => {
-    const makeRequestSpy = jest.spyOn(needle, 'makeRequest');
-    const bundleResponse = await extendBundle({
-      baseURL,
-      sessionToken,
-      source,
-      bundleHash: fakeBundleHashFull,
-      files: {
-        'new.js': 'new123',
-      },
-      removedFiles: [
-        `AnnotatorTest.cpp`,
-        `app.js`,
-        `GitHubAccessTokenScrambler12.java`,
-        `db.js`,
-        `main.js`,
-        'big-file.js',
-        `not/ignored/this_should_be_ignored.jsx`,
-        `not/ignored/this_should_not_be_ignored.java`,
-        `routes/index.js`,
-        `routes/sharks.js`,
-      ],
-      base64Encoding: true,
-    })
-    const requestBody = makeRequestSpy.mock.calls[0][0].body as string;
-    expect(JSON.parse(Buffer.from(requestBody,'base64').toString())).toEqual(
-      {
+    it('extends a base64-encoded bundle', async () => {
+      const makeRequestSpy = jest.spyOn(needle, 'makeRequest');
+      const bundleResponse = await extendBundle({
+        baseURL,
+        sessionToken,
+        source,
+        bundleHash: fakeBundleHashFull,
         files: {
           'new.js': 'new123',
         },
@@ -445,7 +424,25 @@ describe('Base64 encoded operations', () => {
           `routes/index.js`,
           `routes/sharks.js`,
         ],
-      }
-    )
-  })
-})
+        base64Encoding: true,
+      });
+      const requestBody = makeRequestSpy.mock.calls[0][0].body as string;
+      expect(JSON.parse(Buffer.from(requestBody, 'base64').toString())).toEqual({
+        files: {
+          'new.js': 'new123',
+        },
+        removedFiles: [
+          `AnnotatorTest.cpp`,
+          `app.js`,
+          `GitHubAccessTokenScrambler12.java`,
+          `db.js`,
+          `main.js`,
+          'big-file.js',
+          `not/ignored/this_should_be_ignored.jsx`,
+          `not/ignored/this_should_not_be_ignored.java`,
+          `routes/index.js`,
+          `routes/sharks.js`,
+        ],
+      });
+    });
+});

--- a/tests/bundle.spec.ts
+++ b/tests/bundle.spec.ts
@@ -9,6 +9,7 @@ describe('Functional test for bundle creation', () => {
     const paths: string[] = [path.join(sampleProjectPath)];
     const symlinksEnabled = false;
     const defaultFileIgnores = undefined;
+    const base64Encoding = false;
 
     const result = await createBundleFromFolders({
       baseURL,
@@ -17,6 +18,7 @@ describe('Functional test for bundle creation', () => {
       paths,
       symlinksEnabled,
       defaultFileIgnores,
+      base64Encoding,
     });
 
     expect(result).not.toBeNull();

--- a/tests/constants/sample.ts
+++ b/tests/constants/sample.ts
@@ -42,7 +42,7 @@ export const bundleFilePaths = [
   'not/ignored/this_should_not_be_ignored.java',
 ];
 
-async function getBundleFiles(withContent: boolean) {
+async function getBundleFiles(withContent: boolean, bundleFilePaths: Array<string>) {
   return (
     await Promise.all(
       bundleFilePaths.map(f => getFileInfo(path.join(sampleProjectPath, f), sampleProjectPath, withContent)),
@@ -50,8 +50,9 @@ async function getBundleFiles(withContent: boolean) {
   ).filter(notEmpty);
 }
 
-export const bundleFiles: Promise<FileInfo[]> = getBundleFiles(false);
-export const bundleFilesFull: Promise<FileInfo[]> = getBundleFiles(true);
+export const bundleFiles: Promise<FileInfo[]> = getBundleFiles(false, bundleFilePaths);
+export const bundleFilesFull: Promise<FileInfo[]> = getBundleFiles(true, bundleFilePaths);
+export const singleBundleFull: Promise<FileInfo[]> = getBundleFiles(true, [bundleFilePaths[0]]);
 
 export const bundleExtender: () => Promise<{
   files: { removed: string; changed: string; added: string; all: string[] };


### PR DESCRIPTION
#### What does this PR do?
This PR adds the capability to `base64` encode payloads created by the `snyk code test` with the `options.base64Encoding` flag.

This feature is added to allow `base64` encoded payloads to be passed to `deeproxy` for single-tenant solutions, obfuscating source code and preventing Akamai WAF rules incorrectly flagging code transmitted in the payload.

Enabling `base64` encoding requires `deeproxy` to be deployed *and* with the `base64` encode flag enabled also.

#### Ref
https://snyksec.atlassian.net/browse/NEBULA-520