### PR TITLE
fix: retry on when getting 500 resp

### DIFF
--- a/src/needle.ts
+++ b/src/needle.ts
@@ -112,6 +112,7 @@ export async function makeRequest<T = void>(
         ErrorCodes.connectionRefused,
         ErrorCodes.timeout,
         ErrorCodes.dnsNotFound,
+        ErrorCodes.serverError,
       ].includes(errorCode)
     ) {
       attempts--;


### PR DESCRIPTION
When calling upstream services, depending on the HTTP code returned we may retry up to 10 times. This already applies to 503, 502,421, 504 and 452 but NOT 500's

If we get a 500 back we don't retry and immediately return a failure. This PR changes it so that on 500's we do the retries, this should help network/application resiliency. 