### PR TITLE
[NEBULA-549] fix: lock needle version to 3.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "lodash.pick": "^4.4.0",
     "lodash.union": "^4.6.0",
     "multimatch": "^5.0.0",
-    "needle": "^3.0.0",
+    "needle": "~3.0.0",
     "p-map": "^3.0.0",
     "uuid": "^8.3.2",
     "yaml": "^2.0.1"


### PR DESCRIPTION
https://snyksec.atlassian.net/browse/NEBULA-549

Fix needle version to 3.0.x, not 3.x.y. This prevents us from pulling in https://github.com/tomas/needle/pull/382 which causes problems with how we're currently using global-agent to configure the proxy for code-client, both in cli and code-agent.

In parallel we will look into a more permanent solution that is compatible with newer needle versions and properly uses CONNECT requests, e.g., tunnel.