### PR TITLE
fix: support multi-tenant EU auth verification [ROAD-917]

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -155,7 +155,7 @@ export async function checkSession(options: CheckSessionOptions): Promise<Result
   };
 
   const res = await makeRequest<IApiTokenResponse>({
-    url: `${options.authHost}/api/v1/verify/callback`,
+    url: `${options.authHost}/api/verify/callback`,
     body: {
       token: options.draftToken,
     },

--- a/src/http.ts
+++ b/src/http.ts
@@ -9,6 +9,7 @@ import { BundleFiles, SupportedFiles } from './interfaces/files.interface';
 import { AnalysisResult } from './interfaces/analysis-result.interface';
 import { FailedResponse, makeRequest, Payload } from './needle';
 import { AnalysisOptions, AnalysisContext } from './interfaces/analysis-options.interface';
+import { URL } from 'url';
 
 type ResultSuccess<T> = { type: 'success'; value: T };
 type ResultError<E> = {
@@ -118,7 +119,7 @@ export async function getIpFamily(authHost: string): Promise<IpFamily> {
   // Dispatch a FORCED IPv6 request to test client's ISP and network capability
   const res = await makeRequest(
     {
-      url: `${authHost}/verify/callback`,
+      url: getVerifyCallbackUrl(authHost),
       method: 'post',
       family, // family param forces the handler to dispatch a request using IP at "family" version
     },
@@ -155,7 +156,7 @@ export async function checkSession(options: CheckSessionOptions): Promise<Result
   };
 
   const res = await makeRequest<IApiTokenResponse>({
-    url: `${options.authHost}/api/verify/callback`,
+    url: getVerifyCallbackUrl(options.authHost),
     body: {
       token: options.draftToken,
     },
@@ -406,4 +407,8 @@ export async function getAnalysis(
   const res = await makeRequest<GetAnalysisResponseDto>(config);
   if (res.success) return { type: 'success', value: res.body };
   return generateError<GetAnalysisErrorCodes>(res.errorCode, GET_ANALYSIS_ERROR_MESSAGES, 'getAnalysis');
+}
+
+export function getVerifyCallbackUrl(authHost: string): string {
+  return `${authHost}/api/verify/callback`;
 }

--- a/tests/http.spec.ts
+++ b/tests/http.spec.ts
@@ -1,4 +1,5 @@
 import needle from 'needle';
+import { getVerifyCallbackUrl } from '../src/http';
 
 describe('HTTP', () => {
   const authHost = 'https://dev.snyk.io';
@@ -33,5 +34,11 @@ describe('HTTP', () => {
     const family = await http.getIpFamily(authHost);
 
     expect(family).toBe(undefined);
+  });
+
+  it('should obtain correct verify/callback endpoint url', async () => {
+    const url = getVerifyCallbackUrl(authHost);
+
+    expect(url).toBe(`${authHost}/api/verify/callback`);
   });
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Linked to Jira ticket

#### What does this PR do?
It enables VS Code extension to authenticate using `https://app.eu.snyk.io` authentication host in multi-tenant.

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?
The route to the verify/callback API endpoint has been changed, see [this thread](https://snyk.slack.com/archives/C038SPUVBEU/p1656600323231699).

#### Screenshots

#### Additional questions
