### PR TITLE
fix[ZEN-371, COD-841]: allow capitalised extensions

### DIFF
--- a/src/files.ts
+++ b/src/files.ts
@@ -1,6 +1,6 @@
 import * as nodePath from 'path';
 import * as fs from 'fs';
-import fg from 'fast-glob';
+import fg, { Options } from 'fast-glob';
 import multimatch from 'multimatch';
 import crypto from 'crypto';
 import { parse as parseYaml } from 'yaml';
@@ -183,6 +183,7 @@ async function* searchFiles(
   symlinksEnabled: boolean,
   ignores: string[],
 ): AsyncGenerator<string | Buffer> {
+  const optionsForFileSearch: Options = {...fgOptions, caseSensitiveMatch: false}
   const positiveIgnores = ignores.filter(rule => !rule.startsWith('!'));
   const negativeIgnores = ignores.filter(rule => rule.startsWith('!')).map(rule => rule.substring(1));
   // We need to use the ignore rules directly in the stream. Otherwise we would expand all the branches of the file system
@@ -193,7 +194,7 @@ async function* searchFiles(
   // expands those branches that should be excluded from the ignore rules throught the negative ignores as search term
   // and then matches the extensions as a second step to exclude any file that should not be analyzed.
   const positiveSearcher = fg.stream(patterns, {
-    ...fgOptions,
+    ...optionsForFileSearch,
     cwd,
     followSymbolicLinks: symlinksEnabled,
     ignore: positiveIgnores,
@@ -208,7 +209,7 @@ async function* searchFiles(
   // `node_module/my_module/build/` <= re-includes the `build` subfolder in the ignore
   if (negativeIgnores.length) {
     const negativeSearcher = fg.stream(negativeIgnores, {
-      ...fgOptions,
+      ...optionsForFileSearch,
       cwd,
       followSymbolicLinks: symlinksEnabled,
       baseNameMatch: false,

--- a/tests/constants/sample.ts
+++ b/tests/constants/sample.ts
@@ -32,6 +32,7 @@ export const bundleFilePaths = [
   'GitHubAccessTokenScrambler12.java',
   'app.js',
   'db.js',
+  'file-with-capital-extension.JS',
   'main.js',
   'big-file.js', // <= file size is over the custom MAX_FILE_SIZE
   'routes/index.js',

--- a/tests/constants/sample.ts
+++ b/tests/constants/sample.ts
@@ -23,7 +23,7 @@ export const bundleFileIgnores = [
   `${sampleProjectPath}/**/*.jsx`,
   `${sampleProjectPath}/**/exclude/excluded-file.js/**`,
   `${sampleProjectPath}/**/exclude/excluded-file.js`,
-  `${sampleProjectPath}/exclude/excluded-folder/**`,
+  `${sampleProjectPath}/exclude/excluded-folder/**`
 ];
 
 export const bundleFilePaths = [

--- a/tests/files.spec.ts
+++ b/tests/files.spec.ts
@@ -103,7 +103,7 @@ describe('files', () => {
     expect(payloads.length).toEqual(4); // 3 chunks
     expect(payloads[0].length).toEqual(3);
 
-    const testPayload = payloads[0][1];
+    const testPayload = payloads[3][0];
     expect(testPayload.filePath).toEqual(`${sampleProjectPath}/routes/sharks.js`);
     expect(testPayload.bundlePath).toEqual(`routes/sharks.js`);
     expect(testPayload.size).toEqual(363);

--- a/tests/files.spec.ts
+++ b/tests/files.spec.ts
@@ -15,116 +15,129 @@ import {
 import { sampleProjectPath, supportedFiles, bundleFiles, bundleFilesFull, bundleFileIgnores } from './constants/sample';
 
 describe('files', () => {
-  it('parse dc ignore file', () => {
-    const patterns = parseFileIgnores(`${sampleProjectPath}/.dcignore`);
-    expect(patterns).toEqual(bundleFileIgnores.slice(1, 10));
-  });
-  it('parse dot snyk file', () => {
-    const patterns = parseFileIgnores(`${sampleProjectPath}/.snyk`);
-    expect(patterns).toEqual(bundleFileIgnores.slice(10));
-  });
-  it('parse dot snyk file with only one field', () => {
-    const patterns = parseFileIgnores(`${sampleProjectPath}/exclude/.snyk`);
-    expect(patterns).toEqual(bundleFileIgnores.slice(12));
-  });
 
-  it('collect ignore rules', async () => {
-    const ignoreRules = await collectIgnoreRules([sampleProjectPath]);
-    expect(ignoreRules).toEqual(bundleFileIgnores);
-  });
-
-  it('collect bundle files', async () => {
-    // TODO: We should introduce some performance test using a big enough repo to avoid flaky results
-    const collector = collectBundleFiles({
-      baseDir: sampleProjectPath,
-      paths: [sampleProjectPath],
-      supportedFiles,
-      fileIgnores: bundleFileIgnores,
+  describe('parseIgnoreFiles', () => {
+    it('should parse dc ignore file', () => {
+      const patterns = parseFileIgnores(`${sampleProjectPath}/.dcignore`);
+      expect(patterns).toEqual(bundleFileIgnores.slice(1, 10));
     });
-    const files = [];
-    const skippedOversizedFiles = [];
-    for await (const f of collector) {
-      typeof f == 'string' ? skippedOversizedFiles.push(f) : files.push(f);
-    }
-    // all files in the repo are expected other than the file that exceeds MAX_FILE_SIZE 'big-file.js'
-    expect(files).toEqual((await bundleFiles).filter(obj => !obj.bundlePath.includes('big-file.js')));
-
-    // big-file.js should be added to skippedOversizedFiles
-    expect(skippedOversizedFiles.length).toEqual(1);
-    expect(skippedOversizedFiles[0]).toEqual('big-file.js');
-
-    const testFile = files[1];
-    expect(testFile.bundlePath).toEqual('AnnotatorTest.cpp');
-    expect(testFile.hash).toEqual('61b028b49c2a4513b1c7c161b5f491264fe71c9c29bc0ae8e6d760c156b45edc');
-    expect(testFile.filePath).toEqual(`${sampleProjectPath}/AnnotatorTest.cpp`);
-    expect(testFile.bundlePath).toEqual(`AnnotatorTest.cpp`);
-    expect(testFile.size).toEqual(239);
-  });
-
-  it('extend bundle files', async () => {
-    const testNewFiles = [`app.js`, `not/ignored/this_should_not_be_ignored.java`];
-    const testRemovedFiles = [`removed_from_the_parent_bundle.java`, `ignored/this_should_be_ignored.java`];
-    const newBundle = [...testNewFiles, ...testRemovedFiles];
-    const { files, removedFiles } = await prepareExtendingBundle(
-      sampleProjectPath,
-      supportedFiles,
-      bundleFileIgnores,
-      newBundle,
-    );
-    expect(files).toEqual((await bundleFiles).filter(obj => testNewFiles.includes(obj.bundlePath)));
-    expect(removedFiles).toEqual(['removed_from_the_parent_bundle.java']);
-  });
-
-  it('collect bundle files with multiple folders', async () => {
-    // Limit size and we get fewer files
-    const folders = [nodePath.join(sampleProjectPath, 'models'), nodePath.join(sampleProjectPath, 'controllers')];
-    const collector = collectBundleFiles({
-      baseDir: sampleProjectPath,
-      paths: folders,
-      supportedFiles,
-      fileIgnores: [],
+    it('should parse dot snyk file', () => {
+      const patterns = parseFileIgnores(`${sampleProjectPath}/.snyk`);
+      expect(patterns).toEqual(bundleFileIgnores.slice(10));
     });
-    const smallFiles = [];
-    const skippedOversizedFiles = [];
-    for await (const f of collector) {
-      typeof f == 'string' ? skippedOversizedFiles.push(f) : smallFiles.push(f);
-    }
-    expect(smallFiles.length).toEqual(2);
-    expect(skippedOversizedFiles.length).toEqual(0);
-    expect(smallFiles.map(f => [f.filePath, f.bundlePath])).toEqual([
-      [`${sampleProjectPath}/models/sharks.js`, 'models/sharks.js'],
-      [`${sampleProjectPath}/controllers/sharks.js`, 'controllers/sharks.js'],
-    ]);
+    it('should parse dot snyk file with only one field', () => {
+      const patterns = parseFileIgnores(`${sampleProjectPath}/exclude/.snyk`);
+      expect(patterns).toEqual(bundleFileIgnores.slice(12));
+    });
   });
 
-  it('compose file payloads', async () => {
-    // Prepare all missing files first
-    const payloads = [...composeFilePayloads(await bundleFilesFull, 1024)];
-    expect(payloads.length).toEqual(4); // 3 chunks
-    expect(payloads[0].length).toEqual(3);
-
-    const testPayload = payloads[3][0];
-    expect(testPayload.filePath).toEqual(`${sampleProjectPath}/routes/sharks.js`);
-    expect(testPayload.bundlePath).toEqual(`routes/sharks.js`);
-    expect(testPayload.size).toEqual(363);
-    expect(testPayload.hash).toEqual('f870a225bfad387cd3c46ccfb0be52415aa2e07767b53edae54c41fa8e12e82e');
-    expect(testPayload.content).toEqual(fs.readFileSync(testPayload.filePath).toString('utf8'));
+  describe('collectIgnoreRules', () => {
+    it('should collect ignore rules', async () => {
+      const ignoreRules = await collectIgnoreRules([sampleProjectPath]);
+      expect(ignoreRules).toEqual(bundleFileIgnores);
+    })
   });
 
-  it('support of utf-8 encoding', async () => {
-    // fs.readFileSync(payloads[0][0].path).toString('utf8')
-    const filePath = `${sampleProjectPath}/app.js`;
-    const fileMeta = await getFileInfo(filePath, sampleProjectPath);
-    expect(fileMeta?.hash).toEqual('40f937553fda7b9986c3a87d39802b96e77fb2ba306dd602f9b2d28949316c98');
+  describe('collect bundle files', () => {
+    it('should collect bundle files', async () => {
+      // TODO: We should introduce some performance test using a big enough repo to avoid flaky results
+      const collector = collectBundleFiles({
+        baseDir: sampleProjectPath,
+        paths: [sampleProjectPath],
+        supportedFiles,
+        fileIgnores: bundleFileIgnores,
+      });
+      const files = [];
+      const skippedOversizedFiles = [];
+      for await (const f of collector) {
+        typeof f == 'string' ? skippedOversizedFiles.push(f) : files.push(f);
+      }
+      // all files in the repo are expected other than the file that exceeds MAX_FILE_SIZE 'big-file.js'
+      expect(files).toEqual((await bundleFiles).filter(obj => !obj.bundlePath.includes('big-file.js')));
+
+      // big-file.js should be added to skippedOversizedFiles
+      expect(skippedOversizedFiles.length).toEqual(1);
+      expect(skippedOversizedFiles[0]).toEqual('big-file.js');
+
+      const testFile = files[1];
+      expect(testFile.bundlePath).toEqual('AnnotatorTest.cpp');
+      expect(testFile.hash).toEqual('61b028b49c2a4513b1c7c161b5f491264fe71c9c29bc0ae8e6d760c156b45edc');
+      expect(testFile.filePath).toEqual(`${sampleProjectPath}/AnnotatorTest.cpp`);
+      expect(testFile.bundlePath).toEqual(`AnnotatorTest.cpp`);
+      expect(testFile.size).toEqual(239);
+    });
+
+    it('should collect bundle files with multiple folders', async () => {
+      // Limit size and we get fewer files
+      const folders = [nodePath.join(sampleProjectPath, 'models'), nodePath.join(sampleProjectPath, 'controllers')];
+      const collector = collectBundleFiles({
+        baseDir: sampleProjectPath,
+        paths: folders,
+        supportedFiles,
+        fileIgnores: [],
+      });
+      const smallFiles = [];
+      const skippedOversizedFiles = [];
+      for await (const f of collector) {
+        typeof f == 'string' ? skippedOversizedFiles.push(f) : smallFiles.push(f);
+      }
+      expect(smallFiles.length).toEqual(2);
+      expect(skippedOversizedFiles.length).toEqual(0);
+      expect(smallFiles.map(f => [f.filePath, f.bundlePath])).toEqual([
+        [`${sampleProjectPath}/models/sharks.js`, 'models/sharks.js'],
+        [`${sampleProjectPath}/controllers/sharks.js`, 'controllers/sharks.js'],
+      ]);
+    });
   });
 
-  it('support of iso8859 encoding', async () => {
-    const filePath = `${sampleProjectPath}/main.js`;
-    const fileMeta = await getFileInfo(filePath, sampleProjectPath);
-    expect(fileMeta?.hash).toEqual('3e2979852cc2e97f48f7e7973a8b0837eb73ed0485c868176bc3aa58c499f534');
+  describe('prepareExtendingBundle', () => {
+    it('should extend bundle files', async () => {
+      const testNewFiles = [`app.js`, `not/ignored/this_should_not_be_ignored.java`];
+      const testRemovedFiles = [`removed_from_the_parent_bundle.java`, `ignored/this_should_be_ignored.java`];
+      const newBundle = [...testNewFiles, ...testRemovedFiles];
+      const { files, removedFiles } = await prepareExtendingBundle(
+        sampleProjectPath,
+        supportedFiles,
+        bundleFileIgnores,
+        newBundle,
+      );
+      expect(files).toEqual((await bundleFiles).filter(obj => testNewFiles.includes(obj.bundlePath)));
+      expect(removedFiles).toEqual(['removed_from_the_parent_bundle.java']);
+    });
   });
 
-  it('gets correct bundle file path if no baseDir specified', () => {
+  describe('composeFilePayloads', () => {
+    it('should compose file payloads', async () => {
+      // Prepare all missing files first
+      const payloads = [...composeFilePayloads(await bundleFilesFull, 1024)];
+      expect(payloads.length).toEqual(4); // 3 chunks
+      expect(payloads[0].length).toEqual(3);
+
+      const testPayload = payloads[3][0];
+      expect(testPayload.filePath).toEqual(`${sampleProjectPath}/routes/sharks.js`);
+      expect(testPayload.bundlePath).toEqual(`routes/sharks.js`);
+      expect(testPayload.size).toEqual(363);
+      expect(testPayload.hash).toEqual('f870a225bfad387cd3c46ccfb0be52415aa2e07767b53edae54c41fa8e12e82e');
+      expect(testPayload.content).toEqual(fs.readFileSync(testPayload.filePath).toString('utf8'));
+    });
+  });
+
+  describe('getFileInfo', () => {
+    it('should support of utf-8 encoding', async () => {
+      const filePath = `${sampleProjectPath}/app.js`;
+      const fileMeta = await getFileInfo(filePath, sampleProjectPath);
+      expect(fileMeta?.hash).toEqual('40f937553fda7b9986c3a87d39802b96e77fb2ba306dd602f9b2d28949316c98');
+    });
+
+    it('should support of iso8859 encoding', async () => {
+      const filePath = `${sampleProjectPath}/main.js`;
+      const fileMeta = await getFileInfo(filePath, sampleProjectPath);
+      expect(fileMeta?.hash).toEqual('3e2979852cc2e97f48f7e7973a8b0837eb73ed0485c868176bc3aa58c499f534');
+    });
+  });
+
+
+  it('getBundleFilePath - should get correct bundle file path if no baseDir specified', () => {
     const baseDir = '';
     const darwinPath = '/Users/user/Git/goof/routes/index.js';
     expect(getBundleFilePath(darwinPath, baseDir)).toEqual(darwinPath);
@@ -136,7 +149,7 @@ describe('files', () => {
     expect(getBundleFilePath(windowsPath, baseDir)).toEqual(encodeURI(windowsPath));
   });
 
-  it('resolves correct bundle file path if no baseDir specified and contains whitespace', () => {
+  it('resolveBundleFilePath - should resolve correct bundle file path if no baseDir specified and contains whitespace', () => {
     const baseDir = '';
     const darwinPath = '/Users/user/Git/goof%20test/routes/index.js';
     expect(resolveBundleFilePath(baseDir, darwinPath)).toEqual(decodeURI(darwinPath));

--- a/tests/files.spec.ts
+++ b/tests/files.spec.ts
@@ -100,8 +100,8 @@ describe('files', () => {
   it('compose file payloads', async () => {
     // Prepare all missing files first
     const payloads = [...composeFilePayloads(await bundleFilesFull, 1024)];
-    expect(payloads.length).toEqual(3); // 3 chunks
-    expect(payloads[0].length).toEqual(2);
+    expect(payloads.length).toEqual(4); // 3 chunks
+    expect(payloads[0].length).toEqual(3);
 
     const testPayload = payloads[0][1];
     expect(testPayload.filePath).toEqual(`${sampleProjectPath}/routes/sharks.js`);

--- a/tests/sample-repo/file-with-capital-extension.JS
+++ b/tests/sample-repo/file-with-capital-extension.JS
@@ -1,0 +1,3 @@
+function testFunction () {
+    return null;
+}

--- a/tests/sample-repo/folder-with-capitalised-ignore-file/.SNYK
+++ b/tests/sample-repo/folder-with-capitalised-ignore-file/.SNYK
@@ -1,0 +1,3 @@
+exclude:
+  global:
+    - rule-that-should-not-be-here-because-file-is-capitalised


### PR DESCRIPTION
#### What does this PR do?

While working on one of the customer tickets, I found that capitalised file extensions are not picked up by our files parser - which is not the case for the UI. After some [discussions](https://snyk.slack.com/archives/C0370TRPF7F/p1665399622050539) within the team, we have decided to align that functionality and respect capitalised file extensions.

#### How should this be manually tested?

Try a folder that contains files with, for example, a `.JS` extension. It shouldn't work with the previous version (no files will be found) but it should be fine with this change.
