### PR TITLE
fix: fixed http library to properly set API header with organization …

### DIFF
--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -100,7 +100,6 @@ export async function analyzeFolders(options: FileAnalysisOptions): Promise<File
     ...options.connection,
     ...options.fileOptions,
     languages: options.languages,
-    ...(options.analysisContext ? { analysisContext: options.analysisContext } : {}),
   });
   if (fileBundle === null) return null;
 

--- a/src/bundles.ts
+++ b/src/bundles.ts
@@ -250,10 +250,9 @@ export async function createBundleFromFolders(options: CreateBundleFromFoldersOp
   }
 
   const bundleOptions = {
-    ...pick(options, ['baseURL', 'sessionToken', 'source', 'requestId']),
+    ...pick(options, ['baseURL', 'sessionToken', 'source', 'requestId', 'org']),
     baseDir,
     files: bundleFiles,
-    ...(options.analysisContext?.org?.name ? { org: options.analysisContext.org.name } : {}),
   };
 
   // Create remote bundle

--- a/src/http.ts
+++ b/src/http.ts
@@ -181,7 +181,7 @@ export async function getFilters(
   return generateError<GenericErrorTypes>(res.errorCode, GENERIC_ERROR_MESSAGES, apiName);
 }
 
-function prepareHeaders(options: ConnectionOptions) {
+function commonHttpHeaders(options: ConnectionOptions) {
   return {
     'Session-Token': options.sessionToken,
     // We need to be able to test code-client without deepcode locally
@@ -226,7 +226,7 @@ export async function createBundle(
     headers: {
       'content-type': 'application/octet-stream',
       'content-encoding': 'gzip',
-      ...prepareHeaders(options),
+      ...commonHttpHeaders(options),
     },
     url: `${options.baseURL}/bundle`,
     method: 'post',
@@ -260,7 +260,9 @@ interface CheckBundleOptions extends ConnectionOptions {
 
 export async function checkBundle(options: CheckBundleOptions): Promise<Result<RemoteBundle, CheckBundleErrorCodes>> {
   const res = await makeRequest<RemoteBundle>({
-    headers: prepareHeaders(options),
+    headers: {
+      ...commonHttpHeaders(options),
+    },
     url: `${options.baseURL}/bundle/${options.bundleHash}`,
     method: 'get',
   });
@@ -300,7 +302,7 @@ export async function extendBundle(
     headers: {
       'content-type': 'application/octet-stream',
       'content-encoding': 'gzip',
-      ...prepareHeaders(options),
+      ...commonHttpHeaders(options),
     },
     url: `${options.baseURL}/bundle/${options.bundleHash}`,
     method: 'put',
@@ -357,8 +359,7 @@ export async function getAnalysis(
 ): Promise<Result<GetAnalysisResponseDto, GetAnalysisErrorCodes>> {
   const config: Payload = {
     headers: {
-      ...prepareHeaders(options),
-      ...(options.analysisContext?.org?.name && { 'snyk-org-name': options.analysisContext.org.name }),
+      ...commonHttpHeaders(options),
     },
     url: `${options.baseURL}/analysis`,
     method: 'post',
@@ -396,10 +397,7 @@ export async function initReport(
 ): Promise<Result<InitUploadResponseDto, GetAnalysisErrorCodes>> {
   const config: Payload = {
     headers: {
-      ...prepareTokenHeaders(options.sessionToken),
-      source: options.source,
-      ...(options.requestId && { 'snyk-request-id': options.requestId }),
-      ...(options.org && { 'snyk-org-name': options.org }),
+      ...commonHttpHeaders(options),
     },
     url: `${options.baseURL}/report`,
     method: 'post',
@@ -427,10 +425,7 @@ export async function getReport(
 ): Promise<Result<UploadReportResponseDto, GetAnalysisErrorCodes>> {
   const config: Payload = {
     headers: {
-      ...prepareTokenHeaders(options.sessionToken),
-      source: options.source,
-      ...(options.requestId && { 'snyk-request-id': options.requestId }),
-      ...(options.org && { 'snyk-org-name': options.org }),
+      ...commonHttpHeaders(options),
     },
     url: `${options.baseURL}/report/${options.reportId}`,
     method: 'get',

--- a/src/interfaces/analysis-options.interface.ts
+++ b/src/interfaces/analysis-options.interface.ts
@@ -39,15 +39,7 @@ export interface AnalysisContext {
   };
 }
 
-export interface FileAnalysisOptions extends AnalysisContext {
-  connection: ConnectionOptions;
-  analysisOptions: AnalysisOptions;
-  fileOptions: AnalyzeFoldersOptions;
-  reportOptions?: ReportOptions;
-  languages?: string[];
-}
-
-export interface AnalyzeFoldersOptions extends AnalysisContext {
+export interface AnalyzeFoldersOptions {
   paths: string[];
   symlinksEnabled?: boolean;
   defaultFileIgnores?: string[];
@@ -64,4 +56,12 @@ export interface ReportOptions {
   enabled: boolean;
   projectName?: string;
   targetRef?: string;
+}
+
+export interface FileAnalysisOptions extends AnalysisContext {
+  connection: ConnectionOptions;
+  analysisOptions: AnalysisOptions;
+  fileOptions: AnalyzeFoldersOptions;
+  reportOptions?: ReportOptions;
+  languages?: string[];
 }

--- a/tests/analysis.spec.ts
+++ b/tests/analysis.spec.ts
@@ -322,6 +322,7 @@ describe('Functional test of analysis', () => {
           baseURL,
           sessionToken,
           source,
+          org: 'org',
           severity: 1,
           bundleHash: 'hash',
           shard: sampleProjectPath,


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Linked to Jira ticket

#### What does this PR do?

fix: fixed http library to properly set API header with organization name

Currently, we don't set a header with organization name for getAnalysis call.
These changes are all internal and don't affect public API

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots

#### Additional questions
