### PR TITLE
fix: remove body from GET /report/{reportId} request

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -442,9 +442,6 @@ export async function getReport(
     },
     url: `${options.baseURL}/report/${options.reportId}`,
     method: 'get',
-    body: {
-      reportId: options.reportId,
-    },
   };
 
   const res = await makeRequest<UploadReportResponseDto>(config);


### PR DESCRIPTION
GET requests with a request body are rejected at GKE ingress