### PR TITLE
fix: add support for additional report parameters [ZEN-556]

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -406,6 +406,9 @@ export async function initReport(
     body: {
       workflowData: {
         projectName: options.report.projectName,
+        targetName: options.report.targetName,
+        targetRef: options.report.targetRef,
+        remoteRepoUrl: options.report.remoteRepoUrl,
       },
       key: {
         type: 'file',

--- a/src/interfaces/analysis-options.interface.ts
+++ b/src/interfaces/analysis-options.interface.ts
@@ -55,7 +55,9 @@ export interface CollectBundleFilesOptions extends AnalyzeFoldersOptions {
 export interface ReportOptions {
   enabled: boolean;
   projectName?: string;
+  targetName?: string;
   targetRef?: string;
+  remoteRepoUrl?: string;
 }
 
 export interface FileAnalysisOptions extends AnalysisContext {

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -2,19 +2,8 @@ import pick from 'lodash.pick';
 
 import { baseURL, sessionToken, source, TEST_TIMEOUT } from './constants/base';
 import { bundleFiles, bundleFilesFull, singleBundleFull } from './constants/sample';
-import {
-  getFilters,
-  createBundle,
-  checkBundle,
-  extendBundle,
-  getAnalysis,
-  AnalysisStatus,
-  initReport,
-  getReport,
-} from '../src/http';
+import { getFilters, createBundle, checkBundle, extendBundle, getAnalysis, AnalysisStatus } from '../src/http';
 import { BundleFiles } from '../src/interfaces/files.interface';
-import * as needle from '../src/needle';
-import { gunzipSync } from 'zlib';
 
 const fakeBundleHash = 'd9f1171fb6f6bf12eb217fee43eef3cebd6a85cc78bc333035bf4cc3ebf1cf68';
 let fakeBundleHashFull = '';

--- a/tests/report.spec.ts
+++ b/tests/report.spec.ts
@@ -1,11 +1,11 @@
 import path from 'path';
-import { createBundleFromFolders } from '../src/bundles';
 import { baseURL, sessionToken, source } from './constants/base';
 import { reportBundle } from '../src/report';
 import * as http from '../src/http';
 import { sampleProjectPath, initReportReturn, getReportReturn } from './constants/sample';
 
-jest.spyOn(http, 'initReport').mockReturnValue(Promise.resolve({ type: 'success', value: initReportReturn }));
+const mockInitReport = jest.spyOn(http, 'initReport');
+mockInitReport.mockReturnValue(Promise.resolve({ type: 'success', value: initReportReturn }));
 jest.spyOn(http, 'getReport').mockReturnValue(Promise.resolve({ type: 'success', value: getReportReturn }));
 
 describe('Functional test for report', () => {
@@ -18,24 +18,26 @@ describe('Functional test for report', () => {
     paths,
   };
 
-  it('should report a bundle with correct parameters', async () => {
+  it('should complete report with correct parameters', async () => {
     const reportConfig = {
       enabled: true,
       projectName: 'test-project',
+      targetName: 'test-target',
+      targetRef: 'test-ref',
+      remoteRepoUrl: 'https://github.com/owner/repo',
     };
 
-    const bundleResult = await createBundleFromFolders(baseConfig);
-
-    expect(bundleResult).not.toBeNull();
-    expect(bundleResult).toHaveProperty('bundleHash');
-    const bundleHash = bundleResult?.bundleHash;
-    if (!bundleHash) return;
-
     const result = await reportBundle({
-      bundleHash,
+      bundleHash: 'dummy-bundle',
       ...baseConfig,
       report: reportConfig,
     });
+
+    expect(mockInitReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        report: reportConfig,
+      }),
+    );
 
     expect(result).not.toBeNull();
     expect(result.status).toBe('COMPLETE');
@@ -49,16 +51,9 @@ describe('Functional test for report', () => {
       projectName: undefined,
     };
 
-    const bundleResult = await createBundleFromFolders(baseConfig);
-
-    expect(bundleResult).not.toBeNull();
-    expect(bundleResult).toHaveProperty('bundleHash');
-    const bundleHash = bundleResult?.bundleHash;
-    if (!bundleHash) return;
-
     expect(async () => {
       await reportBundle({
-        bundleHash,
+        bundleHash: 'dummy-bundle',
         ...baseConfig,
         report: reportConfig,
       });


### PR DESCRIPTION
- [x] Ready for review
- [x] Linked to Jira ticket

#### What does this PR do?

Add support and handling for additional report-related params:
- `targetName` (from CLI: `target-name`)
- `targetRef` (from CLI: `target-reference`)
- `remoteRepoUrl` (from CLI: `remote-repo-url`)

CLI companion PR: https://github.com/snyk/cli/pull/4484

TODO:
- [ ] Merge `code-orchestrator` companion PR: https://github.com/snyk/code-orchestrator/pull/40

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots

#### Additional questions
