### PR TITLE
chore: improve report errors [ZEN-541]

### DIFF
--- a/src/needle.ts
+++ b/src/needle.ts
@@ -107,6 +107,8 @@ export async function makeRequest<T = void>(
       emitter.apiRequestLog(`Requested url --> ${url} | error --> ${err}`);
     }
 
+    const errorMessage = new Object(response?.body)['error'];
+    error = error ?? new Error(errorMessage);
     errorCode = errorCode ?? ErrorCodes.serviceUnavailable;
 
     // Try to avoid breaking requests due to temporary network errors

--- a/src/report.ts
+++ b/src/report.ts
@@ -20,8 +20,15 @@ async function pollReport(
 ): Promise<Result<AnalysisFailedResponse | ReportResult, GetAnalysisErrorCodes>> {
   // Return early if project name is not provided.
   const projectName = options.report?.projectName?.trim();
+  const projectNameMaxLength = 64;
   if (!projectName || projectName.length === 0) {
     throw new Error('"project-name" must be provided for "report"');
+  }
+  if (projectName.length > projectNameMaxLength) {
+    throw new Error(`project-name "${projectName}" must not exceed ${projectNameMaxLength} characters`);
+  }
+  if (/[^A-Za-z0-9-_/]/g.test(projectName)) {
+    throw new Error(`project-name "${projectName}" must not contain spaces or special characters except [/-_]`);
   }
 
   emitter.analyseProgress({


### PR DESCRIPTION
- [ ] Ready for review
- [x] Linked to Jira ticket - [ZEN-541](https://snyksec.atlassian.net/browse/ZEN-541)

#### What does this PR do?
Improves error handling and client side error messages for the code report flow.

Related PR: [cli#4562](https://github.com/snyk/cli/pull/4562)

TODO:
 - [ ] add error messages for the cases where some services are not available
 - [ ] ensure backwards-compatibility
 - [ ] add tests (?)

#### How should this be manually tested?
Run `snyk code test --report --project-name=x` with the relevant errors to test the different messages.

#### Screenshots
_Check [CLI PR](https://github.com/snyk/cli/pull/4562)_

[ZEN-541]: https://snyksec.atlassian.net/browse/ZEN-541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ