### PR TITLE
fix: Send valid `Authorization` header

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -184,9 +184,7 @@ export async function getFilters(
 
 function commonHttpHeaders(options: ConnectionOptions) {
   return {
-    'Session-Token': options.sessionToken,
-    // We need to be able to test code-client without deepcode locally
-    Authorization: `Bearer ${options.sessionToken}`,
+    Authorization: options.sessionToken,
     source: options.source,
     ...(options.requestId && { 'snyk-request-id': options.requestId }),
     ...(options.org && { 'snyk-org-name': options.org }),


### PR DESCRIPTION
- [x] Ready for review

#### What does this PR do?

I am changing the AuthN logic to only send the token through the `Authorization` header instead of sending both `session-token` and a dummy `Authorization`.
This change relies on this [Deeproxy PR](https://github.com/snyk/deeproxy/pull/336) 

#### Any background context you want to provide?
In the Deeproxy PR, there is more context on this AuthN change and a diagram of all Deeproxy consumers and how they are affected by this change.