### PR TITLE
feat: implement support for SCM-based analyses with reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,25 @@ const results = await codeClient.analyzeFolders({
 });
 ```
 
+### Run analysis and report results to platform
+
+```javascript
+const results = await codeClient.analyzeFolders({
+  connection: { baseURL, sessionToken, source },
+  analysisOptions: {
+    severity: 1,
+  },
+  fileOptions: {
+    paths: ['/home/user/repo'],
+    symlinksEnabled: false,
+  },
+  reportOptions: {
+    enabled: true,
+    projectName: 'example-project',
+  },
+});
+```
+
 ### Creates a new bundle based on a previously uploaded one
 
 ```javascript
@@ -127,6 +146,21 @@ const results = await codeClient.extendAnalysis({
   },
 });
 
+```
+
+### Run analysis on an existing SCM project and report results to platform
+
+```javascript
+const results = await codeClient.analyzeScmProject({
+  connection: { baseURL, sessionToken, source },
+  analysisOptions: {
+    severity: 1,
+  },
+  reportOptions: {
+    projectId: '<Snyk Project UUID>',
+    commitId: '<Commit SHA to scan>',
+  },
+});
 ```
 
 ### Errors

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "jest": "^26.4.2",
     "jest-extended": "^0.8.0",
     "jsonschema": "^1.2.11",
+    "nock": "^13.3.2",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.1.1",
     "ts-jest": "^26.3.0",

--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -12,6 +12,7 @@ import {
   GetAnalysisResponseDto,
   AnalysisFailedResponse,
   GetAnalysisOptions,
+  ConnectionOptions,
 } from './http';
 import { createBundleFromFolders, remoteBundleFactory } from './bundles';
 import { reportBundle, reportScm } from './report';
@@ -25,10 +26,24 @@ import {
   ReportUploadResult,
   ScmAnalysis,
 } from './interfaces/analysis-result.interface';
-import { FileAnalysisOptions, ScmAnalysisOptions } from './interfaces/analysis-options.interface';
+import { AnalysisContext, FileAnalysisOptions, ScmAnalysisOptions } from './interfaces/analysis-options.interface';
 import { FileAnalysis } from './interfaces/files.interface';
 
 const sleep = (duration: number) => new Promise(resolve => setTimeout(resolve, duration));
+
+function getConnectionOptions(connectionOptions: ConnectionOptions): ConnectionOptions {
+  return {
+    ...connectionOptions,
+    // Ensure requestId is set.
+    requestId: connectionOptions.requestId ?? uuidv4(),
+  };
+}
+
+function getAnalysisContext(
+  analysisContext: AnalysisContext['analysisContext'] | undefined,
+): AnalysisContext | Record<string, never> {
+  return analysisContext ? { analysisContext } : {};
+}
 
 async function pollAnalysis(
   options: GetAnalysisOptions,
@@ -98,11 +113,11 @@ function normalizeResultFiles(files: AnalysisFiles, baseDir: string): AnalysisFi
  * Optionally with reporting of results to the platform.
  */
 export async function analyzeFolders(options: FileAnalysisOptions): Promise<FileAnalysis | null> {
-  if (!options.connection.requestId) {
-    options.connection.requestId = uuidv4();
-  }
+  const connectionOptions = getConnectionOptions(options.connection);
+  const analysisContext = getAnalysisContext(options.analysisContext);
+
   const fileBundle = await createBundleFromFolders({
-    ...options.connection,
+    ...connectionOptions,
     ...options.fileOptions,
     languages: options.languages,
   });
@@ -110,10 +125,10 @@ export async function analyzeFolders(options: FileAnalysisOptions): Promise<File
 
   const config = {
     bundleHash: fileBundle.bundleHash,
-    ...options.connection,
+    ...connectionOptions,
     ...options.analysisOptions,
     shard: calcHash(fileBundle.baseDir),
-    ...(options.analysisContext ? { analysisContext: options.analysisContext } : {}),
+    ...analysisContext,
   };
 
   let analysisResults: AnalysisResult;
@@ -341,15 +356,14 @@ export async function extendAnalysis(options: FileAnalysis & { files: string[] }
  * with reporting of results to the platform.
  */
 export async function analyzeScmProject(options: ScmAnalysisOptions): Promise<ScmAnalysis | null> {
-  if (!options.connection.requestId) {
-    options.connection.requestId = uuidv4();
-  }
+  const connectionOptions = getConnectionOptions(options.connection);
+  const analysisContext = getAnalysisContext(options.analysisContext);
 
   const { analysisResult: analysisResults, uploadResult: reportResults } = await reportScm({
-    ...options.connection,
+    ...connectionOptions,
     ...options.analysisOptions,
-    ...(options.analysisContext ? { analysisContext: options.analysisContext } : {}),
     ...options.reportOptions,
+    ...analysisContext,
   });
 
   return { analysisResults, reportResults };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { analyzeFolders, extendAnalysis } from './analysis';
+import { analyzeFolders, extendAnalysis, analyzeScmProject } from './analysis';
 import { getSupportedFiles, createBundleFromFolders, createBundleWithCustomFiles } from './bundles';
 import { emitter } from './emitter';
 import { startSession, checkSession, getAnalysis, getIpFamily, IpFamily } from './http';
@@ -17,11 +17,13 @@ import {
   Suggestion,
   Marker,
   ReportResult,
+  ScmAnalysis,
 } from './interfaces/analysis-result.interface';
 
 export {
   getGlobPatterns,
   analyzeFolders,
+  analyzeScmProject,
   getSupportedFiles,
   createBundleFromFolders,
   createBundleWithCustomFiles,
@@ -46,4 +48,5 @@ export {
   IpFamily,
   AnalysisContext,
   ReportResult,
+  ScmAnalysis,
 };

--- a/src/interfaces/analysis-options.interface.ts
+++ b/src/interfaces/analysis-options.interface.ts
@@ -60,10 +60,21 @@ export interface ReportOptions {
   remoteRepoUrl?: string;
 }
 
+export interface ScmReportOptions {
+  projectId?: string;
+  commitId?: string;
+}
+
 export interface FileAnalysisOptions extends AnalysisContext {
   connection: ConnectionOptions;
   analysisOptions: AnalysisOptions;
   fileOptions: AnalyzeFoldersOptions;
   reportOptions?: ReportOptions;
   languages?: string[];
+}
+
+export interface ScmAnalysisOptions extends AnalysisContext {
+  connection: ConnectionOptions;
+  analysisOptions: AnalysisOptions;
+  reportOptions: ScmReportOptions;
 }

--- a/src/interfaces/analysis-result.interface.ts
+++ b/src/interfaces/analysis-result.interface.ts
@@ -99,3 +99,8 @@ export interface ReportResult {
 }
 
 export type AnalysisResult = AnalysisResultSarif | AnalysisResultLegacy;
+
+export interface ScmAnalysis {
+  analysisResults: AnalysisResultSarif;
+  reportResults?: ReportUploadResult;
+}

--- a/tests/analysis.spec.ts
+++ b/tests/analysis.spec.ts
@@ -351,7 +351,7 @@ describe('Functional test of analysis', () => {
 
     it('should successfully analyze folder with the report option enabled', async () => {
       const mockReportBundle = jest.spyOn(report, 'reportBundle');
-      mockReportBundle.mockReturnValueOnce(Promise.resolve(getReportReturn));
+      mockReportBundle.mockResolvedValueOnce(getReportReturn);
 
       const bundle = await analyzeFolders({
         connection: { baseURL, sessionToken, source },
@@ -390,7 +390,7 @@ describe('Functional test of analysis', () => {
   describe('analyzeScmProject', () => {
     it('should successfully analyze SCM project', async () => {
       const mockReportScm = jest.spyOn(report, 'reportScm');
-      mockReportScm.mockReturnValueOnce(Promise.resolve(getReportReturn));
+      mockReportScm.mockResolvedValueOnce(getReportReturn);
 
       const result = await analyzeScmProject({
         connection: { baseURL, sessionToken, source },

--- a/tests/analysis.spec.ts
+++ b/tests/analysis.spec.ts
@@ -1,12 +1,12 @@
 import path from 'path';
 import jsonschema from 'jsonschema';
 
-import { analyzeFolders, extendAnalysis, analyzeBundle } from '../src/analysis';
+import { analyzeFolders, extendAnalysis, analyzeBundle, analyzeScmProject } from '../src/analysis';
 import { uploadRemoteBundle } from '../src/bundles';
 import { baseURL, sessionToken, source, TEST_TIMEOUT } from './constants/base';
 import { sampleProjectPath, bundleFilesFull, bundleExtender, getReportReturn } from './constants/sample';
 import { emitter } from '../src/emitter';
-import { AnalysisResponseProgress, Result, UploadReportResponseDto, GetAnalysisErrorCodes } from '../src/http';
+import { AnalysisResponseProgress } from '../src/http';
 import { SupportedFiles } from '../src/interfaces/files.interface';
 import { AnalysisSeverity, AnalysisContext } from '../src/interfaces/analysis-options.interface';
 import * as sarifSchema from './sarif-schema-2.1.0.json';
@@ -384,6 +384,27 @@ describe('Functional test of analysis', () => {
 
       expect(mockReportBundle).not.toHaveBeenCalled();
       expect(bundle).toBeTruthy();
+    });
+  });
+
+  describe('analyzeScmProject', () => {
+    it('should successfully analyze SCM project', async () => {
+      const mockReportScm = jest.spyOn(report, 'reportScm');
+      mockReportScm.mockReturnValueOnce(Promise.resolve(getReportReturn));
+
+      const result = await analyzeScmProject({
+        connection: { baseURL, sessionToken, source },
+        analysisOptions: { severity: AnalysisSeverity.info },
+        reportOptions: {
+          projectId: '00000000-0000-0000-0000-000000000000',
+          commitId: '0000000',
+        },
+      });
+
+      expect(mockReportScm).toHaveBeenCalledTimes(1);
+      expect(result).not.toBeNull();
+      expect(result).toHaveProperty('analysisResults');
+      expect(result).toHaveProperty('reportResults');
     });
   });
 });

--- a/tests/constants/sample.ts
+++ b/tests/constants/sample.ts
@@ -91,7 +91,7 @@ export const bundleExtender: () => Promise<{
   };
 };
 
-export const initReportReturn = { reportId: 'test-reportId' };
+export const initReportReturn = 'test-reportId';
 
 export const getReportReturn = {
   status: 'COMPLETE',

--- a/tests/report.spec.ts
+++ b/tests/report.spec.ts
@@ -18,8 +18,8 @@ describe('Functional test for report', () => {
 
   describe('reportBundle - File-based (bundle) report', () => {
     beforeAll(() => {
-      mockInitReport.mockReturnValue(Promise.resolve({ type: 'success', value: initReportReturn }));
-      mockGetReport.mockReturnValue(Promise.resolve({ type: 'success', value: getReportReturn }));
+      mockInitReport.mockResolvedValue({ type: 'success', value: initReportReturn });
+      mockGetReport.mockResolvedValue({ type: 'success', value: getReportReturn });
     });
 
     afterAll(() => {
@@ -108,9 +108,7 @@ describe('Functional test for report', () => {
       mockGetReport.mockRestore();
       jest
         .spyOn(needle, 'makeRequest')
-        .mockReturnValue(
-          Promise.resolve({ success: false, errorCode: statusCode, error: new Error(expectedErrorMessage) }),
-        );
+        .mockResolvedValueOnce({ success: false, errorCode: statusCode, error: new Error(expectedErrorMessage) });
 
       const reportConfig = {
         enabled: true,
@@ -136,8 +134,8 @@ describe('Functional test for report', () => {
 
   describe('reportScm - SCM-based (Git) report', () => {
     beforeAll(() => {
-      mockInitScmReport.mockReturnValue(Promise.resolve({ type: 'success', value: initReportReturn }));
-      mockGetScmReport.mockReturnValue(Promise.resolve({ type: 'success', value: getReportReturn }));
+      mockInitScmReport.mockResolvedValue({ type: 'success', value: initReportReturn });
+      mockGetScmReport.mockResolvedValue({ type: 'success', value: getReportReturn });
     });
 
     afterAll(() => {
@@ -201,9 +199,7 @@ describe('Functional test for report', () => {
       mockGetScmReport.mockRestore();
       jest
         .spyOn(needle, 'makeRequest')
-        .mockReturnValue(
-          Promise.resolve({ success: false, errorCode: statusCode, error: new Error(expectedErrorMessage) }),
-        );
+        .mockResolvedValueOnce({ success: false, errorCode: statusCode, error: new Error(expectedErrorMessage) });
 
       const reportConfig = {
         projectId: '00000000-0000-0000-0000-000000000000',

--- a/tests/report.spec.ts
+++ b/tests/report.spec.ts
@@ -5,13 +5,9 @@ import * as needle from '../src/needle';
 import { initReportReturn, getReportReturn } from './constants/sample';
 
 const mockInitReport = jest.spyOn(http, 'initReport');
-mockInitReport.mockReturnValue(Promise.resolve({ type: 'success', value: initReportReturn }));
 const mockGetReport = jest.spyOn(http, 'getReport');
-mockGetReport.mockReturnValue(Promise.resolve({ type: 'success', value: getReportReturn }));
 const mockInitScmReport = jest.spyOn(http, 'initScmReport');
-mockInitScmReport.mockReturnValue(Promise.resolve({ type: 'success', value: initReportReturn }));
 const mockGetScmReport = jest.spyOn(http, 'getScmReport');
-mockGetScmReport.mockReturnValue(Promise.resolve({ type: 'success', value: getReportReturn }));
 
 describe('Functional test for report', () => {
   const baseConfig = {
@@ -21,6 +17,16 @@ describe('Functional test for report', () => {
   };
 
   describe('reportBundle - File-based (bundle) report', () => {
+    beforeAll(() => {
+      mockInitReport.mockReturnValue(Promise.resolve({ type: 'success', value: initReportReturn }));
+      mockGetReport.mockReturnValue(Promise.resolve({ type: 'success', value: getReportReturn }));
+    });
+
+    afterAll(() => {
+      mockInitReport.mockRestore();
+      mockGetReport.mockRestore();
+    });
+
     it('should complete report with correct parameters', async () => {
       const reportConfig = {
         enabled: true,
@@ -129,6 +135,16 @@ describe('Functional test for report', () => {
   });
 
   describe('reportScm - SCM-based (Git) report', () => {
+    beforeAll(() => {
+      mockInitScmReport.mockReturnValue(Promise.resolve({ type: 'success', value: initReportReturn }));
+      mockGetScmReport.mockReturnValue(Promise.resolve({ type: 'success', value: getReportReturn }));
+    });
+
+    afterAll(() => {
+      mockInitScmReport.mockRestore();
+      mockGetScmReport.mockRestore();
+    });
+
     it('should complete report with correct parameters', async () => {
       const reportConfig = {
         projectId: '00000000-0000-0000-0000-000000000000',

--- a/tests/report.spec.ts
+++ b/tests/report.spec.ts
@@ -1,128 +1,209 @@
-import path from 'path';
 import { baseURL, sessionToken, source } from './constants/base';
-import { reportBundle } from '../src/report';
+import { reportBundle, reportScm } from '../src/report';
 import * as http from '../src/http';
 import * as needle from '../src/needle';
-import { sampleProjectPath, initReportReturn, getReportReturn } from './constants/sample';
+import { initReportReturn, getReportReturn } from './constants/sample';
 
 const mockInitReport = jest.spyOn(http, 'initReport');
 mockInitReport.mockReturnValue(Promise.resolve({ type: 'success', value: initReportReturn }));
 const mockGetReport = jest.spyOn(http, 'getReport');
 mockGetReport.mockReturnValue(Promise.resolve({ type: 'success', value: getReportReturn }));
+const mockInitScmReport = jest.spyOn(http, 'initScmReport');
+mockInitScmReport.mockReturnValue(Promise.resolve({ type: 'success', value: initReportReturn }));
+const mockGetScmReport = jest.spyOn(http, 'getScmReport');
+mockGetScmReport.mockReturnValue(Promise.resolve({ type: 'success', value: getReportReturn }));
 
 describe('Functional test for report', () => {
-  const paths: string[] = [path.join(sampleProjectPath)];
-
   const baseConfig = {
     baseURL,
     sessionToken,
     source,
-    paths,
   };
 
-  it('should complete report with correct parameters', async () => {
-    const reportConfig = {
-      enabled: true,
-      projectName: 'test-project',
-      targetName: 'test-target',
-      targetRef: 'test-ref',
-      remoteRepoUrl: 'https://github.com/owner/repo',
-    };
+  describe('reportBundle - File-based (bundle) report', () => {
+    it('should complete report with correct parameters', async () => {
+      const reportConfig = {
+        enabled: true,
+        projectName: 'test-project',
+        targetName: 'test-target',
+        targetRef: 'test-ref',
+        remoteRepoUrl: 'https://github.com/owner/repo',
+      };
 
-    const result = await reportBundle({
-      bundleHash: 'dummy-bundle',
-      ...baseConfig,
-      report: reportConfig,
-    });
-
-    expect(mockInitReport).toHaveBeenCalledWith(
-      expect.objectContaining({
-        report: reportConfig,
-      }),
-    );
-
-    expect(result).not.toBeNull();
-    expect(result.status).toBe('COMPLETE');
-    expect(result).toHaveProperty('uploadResult');
-    expect(result).toHaveProperty('analysisResult');
-  });
-
-  it('should fail report if no project name was given', async () => {
-    const reportConfig = {
-      enabled: true,
-      projectName: undefined,
-    };
-
-    await expect(
-      reportBundle({
+      const result = await reportBundle({
         bundleHash: 'dummy-bundle',
         ...baseConfig,
         report: reportConfig,
-      }),
-    ).rejects.toHaveProperty('message', '"project-name" must be provided for "report"');
-  });
+      });
 
-  it('should fail report if the given project name exceeds the maximum length', async () => {
-    const longProjectName = 'a'.repeat(65);
-    const reportConfig = {
-      enabled: true,
-      projectName: longProjectName,
-    };
-
-    await expect(
-      reportBundle({
-        bundleHash: 'dummy-bundle',
-        ...baseConfig,
-        report: reportConfig,
-      }),
-    ).rejects.toHaveProperty('message', `"project-name" must not exceed 64 characters`);
-  });
-
-  it('should fail report if the given project name includes invalid characters', async () => {
-    const invalidProjectName = '*&^%$';
-    const reportConfig = {
-      enabled: true,
-      projectName: invalidProjectName,
-    };
-
-    await expect(
-      reportBundle({
-        bundleHash: 'dummy-bundle',
-        ...baseConfig,
-        report: reportConfig,
-      }),
-    ).rejects.toHaveProperty('message', `"project-name" must not contain spaces or special characters except [/-_]`);
-  });
-
-  it('getReport should return error with received error message rather than generic error message', async () => {
-    const statusCode = 400;
-    const expectedErrorMessage = 'Dummy received error message';
-
-    mockGetReport.mockRestore();
-    jest
-      .spyOn(needle, 'makeRequest')
-      .mockReturnValue(
-        Promise.resolve({ success: false, errorCode: statusCode, error: new Error(expectedErrorMessage) }),
+      expect(mockInitReport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          report: reportConfig,
+        }),
       );
 
-    const reportConfig = {
-      enabled: true,
-      projectName: 'test-project',
-      targetName: 'test-target',
-      targetRef: 'test-ref',
-      remoteRepoUrl: 'https://github.com/owner/repo',
-    };
+      expect(result).not.toBeNull();
+      expect(result.status).toBe('COMPLETE');
+      expect(result).toHaveProperty('uploadResult');
+      expect(result).toHaveProperty('analysisResult');
+    });
 
-    await expect(
-      reportBundle({
-        bundleHash: 'dummy-bundle',
+    it('should fail report if no project name was given', async () => {
+      const reportConfig = {
+        enabled: true,
+        projectName: undefined,
+      };
+
+      await expect(
+        reportBundle({
+          bundleHash: 'dummy-bundle',
+          ...baseConfig,
+          report: reportConfig,
+        }),
+      ).rejects.toHaveProperty('message', '"project-name" must be provided for "report"');
+    });
+
+    it('should fail report if the given project name exceeds the maximum length', async () => {
+      const longProjectName = 'a'.repeat(65);
+      const reportConfig = {
+        enabled: true,
+        projectName: longProjectName,
+      };
+
+      await expect(
+        reportBundle({
+          bundleHash: 'dummy-bundle',
+          ...baseConfig,
+          report: reportConfig,
+        }),
+      ).rejects.toHaveProperty('message', `"project-name" must not exceed 64 characters`);
+    });
+
+    it('should fail report if the given project name includes invalid characters', async () => {
+      const invalidProjectName = '*&^%$';
+      const reportConfig = {
+        enabled: true,
+        projectName: invalidProjectName,
+      };
+
+      await expect(
+        reportBundle({
+          bundleHash: 'dummy-bundle',
+          ...baseConfig,
+          report: reportConfig,
+        }),
+      ).rejects.toHaveProperty('message', `"project-name" must not contain spaces or special characters except [/-_]`);
+    });
+
+    it('getReport should return error with received error message rather than generic error message', async () => {
+      const statusCode = 400;
+      const expectedErrorMessage = 'Dummy received error message';
+
+      mockGetReport.mockRestore();
+      jest
+        .spyOn(needle, 'makeRequest')
+        .mockReturnValue(
+          Promise.resolve({ success: false, errorCode: statusCode, error: new Error(expectedErrorMessage) }),
+        );
+
+      const reportConfig = {
+        enabled: true,
+        projectName: 'test-project',
+        targetName: 'test-target',
+        targetRef: 'test-ref',
+        remoteRepoUrl: 'https://github.com/owner/repo',
+      };
+
+      await expect(
+        reportBundle({
+          bundleHash: 'dummy-bundle',
+          ...baseConfig,
+          report: reportConfig,
+        }),
+      ).rejects.toMatchObject({
+        apiName: 'getReport',
+        statusCode: statusCode,
+        statusText: expectedErrorMessage,
+      });
+    });
+  });
+
+  describe('reportScm - SCM-based (Git) report', () => {
+    it('should complete report with correct parameters', async () => {
+      const reportConfig = {
+        projectId: '00000000-0000-0000-0000-000000000000',
+        commitId: '0000000',
+      };
+
+      const result = await reportScm({
         ...baseConfig,
-        report: reportConfig,
-      }),
-    ).rejects.toMatchObject({
-      apiName: 'getReport',
-      statusCode: statusCode,
-      statusText: expectedErrorMessage,
+        ...reportConfig,
+      });
+
+      expect(mockInitScmReport).toHaveBeenCalledWith(expect.objectContaining(reportConfig));
+
+      expect(result).not.toBeNull();
+      expect(result.status).toBe('COMPLETE');
+      expect(result).toHaveProperty('uploadResult');
+      expect(result).toHaveProperty('analysisResult');
+    });
+
+    it('should fail report if no project ID was given', async () => {
+      await expect(
+        reportScm({
+          ...baseConfig,
+        }),
+      ).rejects.toHaveProperty('message', '"project-id" must be provided for "report"');
+    });
+
+    it('should fail report if the given project ID is not a valid UUID', async () => {
+      await expect(
+        reportScm({
+          ...baseConfig,
+          projectId: 'invalid-id',
+        }),
+      ).rejects.toHaveProperty('message', `"project-id" must be a valid UUID`);
+    });
+
+    it('should fail report if no commit ID was given', async () => {
+      const reportConfig = {
+        projectId: '00000000-0000-0000-0000-000000000000',
+      };
+
+      await expect(
+        reportScm({
+          ...baseConfig,
+          ...reportConfig,
+        }),
+      ).rejects.toHaveProperty('message', '"commit-id" must be provided for "report"');
+    });
+
+    it('getScmReport should return error with received error message rather than generic error message', async () => {
+      const statusCode = 400;
+      const expectedErrorMessage = 'Dummy received error message';
+
+      mockGetScmReport.mockRestore();
+      jest
+        .spyOn(needle, 'makeRequest')
+        .mockReturnValue(
+          Promise.resolve({ success: false, errorCode: statusCode, error: new Error(expectedErrorMessage) }),
+        );
+
+      const reportConfig = {
+        projectId: '00000000-0000-0000-0000-000000000000',
+        commitId: '0000000',
+      };
+
+      await expect(
+        reportScm({
+          ...baseConfig,
+          ...reportConfig,
+        }),
+      ).rejects.toMatchObject({
+        apiName: 'getReport',
+        statusCode: statusCode,
+        statusText: expectedErrorMessage,
+      });
     });
   });
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Linked to Jira ticket

#### What does this PR do?

Adds support for analysing existing SCM projects and reporting results to the platform.

A new exported method is defined called `analyzeScmProject`, which clients can call in order to trigger the SCM analysis/test flow.

The underlying behaviour is similar to the `analyzeFolders` method when `reportOptions.enabled` is `true`, with the main difference being that it does not create a bundle first (since the code is available in a remote repo, a bundle is not needed).
Otherwise it follows the existing logic we have for triggering and polling tests and returning the results once finished, but using dedicated API endpoints (i.e. `/test` instead of `/report`).

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots

#### Additional questions
