### PR TITLE
fix: file tests after fast-glob update

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@types/write": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^4.31.2",
     "@typescript-eslint/parser": "^4.0.1",
+    "commander": "^10.0.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.24.2",
@@ -66,10 +67,9 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.1.1",
     "ts-jest": "^26.3.0",
+    "ts-node": "^10.9.1",
     "typescript": "^4.0.2",
-    "write": "^2.0.0",
-    "commander": "^10.0.0",
-    "ts-node": "^10.9.1"
+    "write": "^2.0.0"
   },
   "dependencies": {
     "@deepcode/dcignore": "^1.0.4",
@@ -79,7 +79,7 @@
     "@types/lodash.union": "^4.6.6",
     "@types/sarif": "^2.1.4",
     "@types/uuid": "^8.3.1",
-    "fast-glob": "^3.2.11",
+    "fast-glob": "3.3.0",
     "ignore": "^5.1.8",
     "lodash.omit": "^4.5.0",
     "lodash.pick": "^4.4.0",

--- a/tests/__snapshots__/files.spec.ts.snap
+++ b/tests/__snapshots__/files.spec.ts.snap
@@ -1,0 +1,90 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`files collect bundle files 1`] = `
+Array [
+  Object {
+    "bundlePath": ".eslintrc.json",
+    "content": undefined,
+    "filePath": "<basePath>/.eslintrc.json",
+    "hash": "d3332248171b63cf6f785a3750a27bf1cd03bc0462458943d937c34494f08106",
+    "size": 186,
+  },
+  Object {
+    "bundlePath": ".snyk",
+    "content": undefined,
+    "filePath": "<basePath>/.snyk",
+    "hash": "92f1200f08dba7ec777a8499f5a6d8ac63d5c3d6ddca58b2069a840fd0132790",
+    "size": 92,
+  },
+  Object {
+    "bundlePath": "AnnotatorTest.Cpp",
+    "content": undefined,
+    "filePath": "<basePath>/AnnotatorTest.Cpp",
+    "hash": "61b028b49c2a4513b1c7c161b5f491264fe71c9c29bc0ae8e6d760c156b45edc",
+    "size": 239,
+  },
+  Object {
+    "bundlePath": "GitHubAccessTokenScrambler12.java",
+    "content": undefined,
+    "filePath": "<basePath>/GitHubAccessTokenScrambler12.java",
+    "hash": "63184d2adbf4a3fe17430f1029eb9d7c0aaa8cf8a00f20199b921175c0f30d2b",
+    "size": 949,
+  },
+  Object {
+    "bundlePath": "app.js",
+    "content": undefined,
+    "filePath": "<basePath>/app.js",
+    "hash": "40f937553fda7b9986c3a87d39802b96e77fb2ba306dd602f9b2d28949316c98",
+    "size": 510,
+  },
+  Object {
+    "bundlePath": "db.js",
+    "content": undefined,
+    "filePath": "<basePath>/db.js",
+    "hash": "6f8d7925b5c86bd6d31b0b23bdce1dcfc94e28a1d5ebdc0ba91fac7dc7e95657",
+    "size": 533,
+  },
+  Object {
+    "bundlePath": "main.js",
+    "content": undefined,
+    "filePath": "<basePath>/main.js",
+    "hash": "3e2979852cc2e97f48f7e7973a8b0837eb73ed0485c868176bc3aa58c499f534",
+    "size": 23098,
+  },
+  Object {
+    "bundlePath": "exclude/.snyk",
+    "content": undefined,
+    "filePath": "<basePath>/exclude/.snyk",
+    "hash": "b33a7db205b03ccb488773ea895d70b6a777366ae850d2f4e3bcec7293831d71",
+    "size": 45,
+  },
+  Object {
+    "bundlePath": "routes/index.js",
+    "content": undefined,
+    "filePath": "<basePath>/routes/index.js",
+    "hash": "86ad66d869e6a1bfb5edbc6a82203eece06db4690e4480b3b69274a5c91052bd",
+    "size": 300,
+  },
+  Object {
+    "bundlePath": "routes/sharks.js",
+    "content": undefined,
+    "filePath": "<basePath>/routes/sharks.js",
+    "hash": "f870a225bfad387cd3c46ccfb0be52415aa2e07767b53edae54c41fa8e12e82e",
+    "size": 363,
+  },
+  Object {
+    "bundlePath": "not/ignored/this_should_be_ignored.jsx",
+    "content": undefined,
+    "filePath": "<basePath>/not/ignored/this_should_be_ignored.jsx",
+    "hash": "3dce2c0456d5f9b6ff64c589047f359b0a7ec390ec1edd20b0070d3399e4e96a",
+    "size": 252,
+  },
+  Object {
+    "bundlePath": "not/ignored/this_should_not_be_ignored.java",
+    "content": undefined,
+    "filePath": "<basePath>/not/ignored/this_should_not_be_ignored.java",
+    "hash": "63184d2adbf4a3fe17430f1029eb9d7c0aaa8cf8a00f20199b921175c0f30d2b",
+    "size": 949,
+  },
+]
+`;

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -5,7 +5,7 @@ import { bundleFiles, bundleFilesFull, singleBundleFull } from './constants/samp
 import { getFilters, createBundle, checkBundle, extendBundle, getAnalysis, AnalysisStatus } from '../src/http';
 import { BundleFiles } from '../src/interfaces/files.interface';
 
-const fakeBundleHash = '4ff3f91bee2ec5e681e75e935cb9d98318bb9cf9b341894d8cdeed8b9cbd4108';
+const fakeBundleHash = '7055a4c63c339c31bdf28defcced19a64e5e87905b896befc522a11d35fbcdc4';
 let fakeBundleHashFull = '';
 const realBundleHash = '';
 let realBundleHashFull = '';
@@ -18,6 +18,7 @@ const fakeMissingFiles = [
   'app.js',
   'db.js',
   'main.js',
+  'exclude/.snyk',
   'big-file.js',
   'routes/index.js',
   'routes/sharks.js',
@@ -201,6 +202,7 @@ describe('Requests to public API', () => {
           `GitHubAccessTokenScrambler12.java`,
           `db.js`,
           `main.js`,
+          'exclude/.snyk',
           'big-file.js',
           `not/ignored/this_should_be_ignored.jsx`,
           `not/ignored/this_should_not_be_ignored.java`,
@@ -255,8 +257,8 @@ describe('Requests to public API', () => {
       });
       expect(response.type).toEqual('success');
       if (response.type !== 'success') return; // TS trick
-      expect(response.value.bundleHash).toContain('36b2e311cda184992c485ecfa6d58a006562763ae115558632467bb0e880cbe9');
-      expect(response.value.missingFiles).toHaveLength(14);
+      expect(response.value.bundleHash).toContain('f7c882573beea05f39af5d1ce92408eb4addfae860f6d8b665ceb1b82765d87e');
+      expect(response.value.missingFiles).toHaveLength(15);
     },
     TEST_TIMEOUT,
   );

--- a/tests/constants/sample.ts
+++ b/tests/constants/sample.ts
@@ -35,6 +35,7 @@ export const bundleFilePaths = [
   'app.js',
   'db.js',
   'main.js',
+  'exclude/.snyk',
   'big-file.js', // <= file size is over the custom MAX_FILE_SIZE
   'routes/index.js',
   'routes/sharks.js',


### PR DESCRIPTION
- [x] Ready for review
- [ ] Linked to Jira ticket

#### What does this PR do?

Following a minor update to `fast-glob` (version `3.3.0`), we are seeing different behaviour for the `searchFiles` function.

The new behaviour is actually the correct one, as there was no reason for `exclude/.snyk` to not have been detected beforehand, so the update seems correct and the tests were updated to reflect the new behaviour.

Furthermore, instead of checking an individual file in the `collect bundle files` test we now check all of the items returned against a snapshot. This will make it much clearer when/if anything changes between the snapshot and actual results.

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots

#### Additional questions
