### PR TITLE
test: fix tests

### DIFF
--- a/tests/analysis.spec.ts
+++ b/tests/analysis.spec.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import nock from 'nock';
 import jsonschema from 'jsonschema';
+import 'jest-extended';
 
 import { analyzeFolders, extendAnalysis, analyzeBundle, analyzeScmProject } from '../src/analysis';
 import { uploadRemoteBundle } from '../src/bundles';
@@ -110,7 +111,7 @@ describe('Functional test of analysis', () => {
 
         // Check if emitter event happened
         expect(onSupportedFilesLoaded).toHaveBeenCalledTimes(2);
-        expect(onScanFilesProgress).toHaveBeenCalledTimes(12);
+        expect(onScanFilesProgress).toHaveBeenCalledTimes(bFiles.length);
         expect(onCreateBundleProgress).toHaveBeenCalledTimes(2);
         expect(onAnalyseProgress).toHaveBeenCalled();
         expect(onAPIRequestLog).toHaveBeenCalled();

--- a/tests/analysis.spec.ts
+++ b/tests/analysis.spec.ts
@@ -87,25 +87,26 @@ describe('Functional test of analysis', () => {
         expect(bundle.analysisResults.timing.analysis).toBeGreaterThanOrEqual(0);
         expect(bundle.analysisResults.timing.fetchingCode).toBeGreaterThanOrEqual(0);
         expect(bundle.analysisResults.timing.queue).toBeGreaterThanOrEqual(0);
-        expect(new Set(bundle.analysisResults.coverage)).toEqual(
-          new Set([
-            {
-              files: 2,
-              isSupported: true,
-              lang: 'Java',
-            },
-            {
-              files: 1,
-              isSupported: true,
-              lang: 'C++ (beta)',
-            },
-            {
-              files: 6,
-              isSupported: true,
-              lang: 'JavaScript',
-            },
-          ]),
-        );
+        expect(bundle.analysisResults.coverage).toIncludeSameMembers([
+          {
+            files: 2,
+            isSupported: true,
+            lang: 'Java',
+            type: 'SUPPORTED',
+          },
+          {
+            files: 1,
+            isSupported: true,
+            lang: 'C++ (beta)',
+            type: 'SUPPORTED',
+          },
+          {
+            files: 6,
+            isSupported: true,
+            lang: 'JavaScript',
+            type: 'SUPPORTED',
+          },
+        ]);
 
         // Check if emitter event happened
         expect(onSupportedFilesLoaded).toHaveBeenCalledTimes(2);
@@ -269,30 +270,32 @@ describe('Functional test of analysis', () => {
         expect(extendedBundle.analysisResults.timing.analysis).toBeGreaterThanOrEqual(0);
         expect(extendedBundle.analysisResults.timing.fetchingCode).toBeGreaterThanOrEqual(0);
         expect(extendedBundle.analysisResults.timing.queue).toBeGreaterThanOrEqual(0);
-        expect(new Set(extendedBundle.analysisResults.coverage)).toEqual(
-          new Set([
-            {
-              files: 2,
-              isSupported: true,
-              lang: 'Java',
-            },
-            {
-              files: 1,
-              isSupported: true,
-              lang: 'C++ (beta)',
-            },
-            {
-              files: 4,
-              isSupported: true,
-              lang: 'JavaScript',
-            },
-            {
-              files: 1,
-              isSupported: true,
-              lang: 'JSX',
-            },
-          ]),
-        );
+        expect(extendedBundle.analysisResults.coverage).toIncludeSameMembers([
+          {
+            files: 2,
+            isSupported: true,
+            lang: 'Java',
+            type: 'SUPPORTED',
+          },
+          {
+            files: 1,
+            isSupported: true,
+            lang: 'C++ (beta)',
+            type: 'SUPPORTED',
+          },
+          {
+            files: 4,
+            isSupported: true,
+            lang: 'JavaScript',
+            type: 'SUPPORTED',
+          },
+          {
+            files: 1,
+            isSupported: true,
+            lang: 'JSX',
+            type: 'SUPPORTED',
+          },
+        ]);
       },
       TEST_TIMEOUT,
     );

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -327,13 +327,7 @@ describe('Requests to public API', () => {
             type: 'SUPPORTED',
           },
           {
-            files: 1,
-            isSupported: true,
-            lang: 'JavaScript',
-            type: 'SUPPORTED',
-          },
-          {
-            files: 6,
+            files: 7,
             isSupported: true,
             lang: 'JavaScript',
             type: 'SUPPORTED',

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -313,34 +313,32 @@ describe('Requests to public API', () => {
       if (response.value.status === AnalysisStatus.complete && response.value.type === 'sarif') {
         expect(response.value.sarif.runs[0].results?.length).toBeGreaterThan(0);
 
-        expect(new Set(response.value.coverage)).toEqual(
-          new Set([
-            {
-              files: 2,
-              isSupported: true,
-              lang: 'Java',
-              type: 'SUPPORTED',
-            },
-            {
-              files: 1,
-              isSupported: true,
-              lang: 'C++ (beta)',
-              type: 'SUPPORTED',
-            },
-            {
-              files: 1,
-              isSupported: true,
-              lang: 'JavaScript',
-              type: 'SUPPORTED',
-            },
-            {
-              files: 6,
-              isSupported: true,
-              lang: 'JavaScript',
-              type: 'SUPPORTED',
-            },
-          ]),
-        );
+        expect(response.value.coverage).toIncludeSameMembers([
+          {
+            files: 2,
+            isSupported: true,
+            lang: 'Java',
+            type: 'SUPPORTED',
+          },
+          {
+            files: 1,
+            isSupported: true,
+            lang: 'C++ (beta)',
+            type: 'SUPPORTED',
+          },
+          {
+            files: 1,
+            isSupported: true,
+            lang: 'JavaScript',
+            type: 'SUPPORTED',
+          },
+          {
+            files: 6,
+            isSupported: true,
+            lang: 'JavaScript',
+            type: 'SUPPORTED',
+          },
+        ]);
       }
 
       // Get analysis results limited to 1 file

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -1,4 +1,5 @@
 import pick from 'lodash.pick';
+import 'jest-extended';
 
 import { baseURL, sessionToken, source, TEST_TIMEOUT } from './constants/base';
 import { bundleFiles, bundleFilesFull, singleBundleFull } from './constants/sample';


### PR DESCRIPTION
- [x] Ready for review
- [x] Linked to Jira ticket

#### What does this PR do?

Updates expected coverage after API deduplication changes (https://github.com/snyk/sast-analysis-api/pull/414).

In an attempt to fix pipeline flakes, this PR also:
- Replaces `Set` comparisons for coverage with `jest-extended`'s `toIncludeSameMembers` matcher.
- Updates expected number of `onScanFilesProgress` events to match number of files in Bundle.