### PR TITLE
fix: remove project name limit from file report flow [ZEN-748]

### DIFF
--- a/src/report.ts
+++ b/src/report.ts
@@ -88,12 +88,8 @@ async function initAndPollReportGeneric(
 
 export async function reportBundle(options: UploadReportOptions): Promise<ReportResult> {
   const projectName = options.report?.projectName?.trim();
-  const projectNameMaxLength = 64;
   if (!projectName || projectName.length === 0) {
     throw new Error('"project-name" must be provided for "report"');
-  }
-  if (projectName.length > projectNameMaxLength) {
-    throw new Error(`"project-name" must not exceed ${projectNameMaxLength} characters`);
   }
   if (/[^A-Za-z0-9-_/]/g.test(projectName)) {
     throw new Error(`"project-name" must not contain spaces or special characters except [/-_]`);

--- a/tests/report.spec.ts
+++ b/tests/report.spec.ts
@@ -69,22 +69,6 @@ describe('Functional test for report', () => {
       ).rejects.toHaveProperty('message', '"project-name" must be provided for "report"');
     });
 
-    it('should fail report if the given project name exceeds the maximum length', async () => {
-      const longProjectName = 'a'.repeat(65);
-      const reportConfig = {
-        enabled: true,
-        projectName: longProjectName,
-      };
-
-      await expect(
-        reportBundle({
-          bundleHash: 'dummy-bundle',
-          ...baseConfig,
-          report: reportConfig,
-        }),
-      ).rejects.toHaveProperty('message', `"project-name" must not exceed 64 characters`);
-    });
-
     it('should fail report if the given project name includes invalid characters', async () => {
       const invalidProjectName = '*&^%$';
       const reportConfig = {


### PR DESCRIPTION
- [x] Ready for review
- [x] Linked to Jira ticket

#### What does this PR do?

Remove the project name limit of 64 characters for the files report flow.

#### Any background context you want to provide?

https://snyk.slack.com/archives/C01DGQ3AT09/p1689238829165069