### PR TITLE
fix: file exclude behaviour [ZEN-588]

### DIFF
--- a/src/bundles.ts
+++ b/src/bundles.ts
@@ -8,7 +8,7 @@ import { BundleFiles, FileInfo, SupportedFiles } from './interfaces/files.interf
 import {
   composeFilePayloads,
   resolveBundleFiles,
-  collectIgnoreRules,
+  collectFilePolicies,
   determineBaseDir,
   collectBundleFiles,
 } from './files';
@@ -265,7 +265,7 @@ export async function createBundleWithCustomFiles(
   supportedFiles: SupportedFiles,
 ): Promise<FileBundle | null> {
   // Scan for custom ignore rules
-  const fileIgnores = await collectIgnoreRules(options.paths, options.symlinksEnabled, options.defaultFileIgnores);
+  const filePolicies = await collectFilePolicies(options.paths, options.symlinksEnabled, options.defaultFileIgnores);
 
   const baseDir = determineBaseDir(options.paths);
   emitter.scanFilesProgress(0);
@@ -275,7 +275,7 @@ export async function createBundleWithCustomFiles(
   const bundleFileCollector = collectBundleFiles({
     ...pick(options, ['paths', 'symlinksEnabled']),
     baseDir,
-    fileIgnores,
+    filePolicies,
     supportedFiles,
   });
   for await (const f of bundleFileCollector) {
@@ -300,7 +300,7 @@ export async function createBundleWithCustomFiles(
     ...remoteBundle,
     baseDir,
     supportedFiles,
-    fileIgnores,
+    fileIgnores: [...filePolicies.excludes, ...filePolicies.ignores],
     skippedOversizedFiles,
   };
 }

--- a/src/files.ts
+++ b/src/files.ts
@@ -249,14 +249,10 @@ async function* searchFiles(
   patterns: string[],
   cwd: string,
   symlinksEnabled: boolean,
-  policies?: FilePolicies,
+  policies: FilePolicies,
 ): AsyncGenerator<string | Buffer> {
-  const positiveIgnores = policies
-    ? [...policies.excludes, ...policies.ignores.filter(rule => !rule.startsWith('!'))]
-    : [];
-  const negativeIgnores = policies
-    ? policies.ignores.filter(rule => rule.startsWith('!')).map(rule => rule.substring(1))
-    : [];
+  const positiveIgnores = [...policies.excludes, ...policies.ignores.filter(rule => !rule.startsWith('!'))];
+  const negativeIgnores = policies.ignores.filter(rule => rule.startsWith('!')).map(rule => rule.substring(1));
   // We need to use the ignore rules directly in the stream. Otherwise we would expand all the branches of the file system
   // that should be ignored, leading to performance issues (the parser would look stuck while analyzing each ignored file).
   // However, fast-glob doesn't address the negative rules in the ignore option correctly.
@@ -287,7 +283,7 @@ async function* searchFiles(
       followSymbolicLinks: symlinksEnabled,
       baseNameMatch: false,
       // Exclude rules should still be respected
-      ignore: policies?.excludes ?? [],
+      ignore: policies.excludes,
     });
     for await (const filePath of negativeSearcher) {
       if (isMatch(filePath.toString(), deepPatterns)) yield filePath;

--- a/src/files.ts
+++ b/src/files.ts
@@ -202,10 +202,12 @@ export async function collectIgnoreRules(
   const customRules = await Promise.all(tasks);
 
   const rules = union(fileIgnores, ...customRules);
-  const deduplicatedRules: string[] = [];
 
+  // Deduplicate rules, such as "**/dir" and "sub/dir".
+  // In this case "sub/dir" is a subset of the first rule and thus redundant.
+  const deduplicatedRules: string[] = [];
   for (const rule of rules) {
-    if (!deduplicatedRules.some(existingRule => multimatch(rule, [existingRule]).length > 0)) {
+    if (!deduplicatedRules.some(existingRule => multimatch(rule, existingRule).length > 0)) {
       deduplicatedRules.push(rule);
     }
   }

--- a/src/files.ts
+++ b/src/files.ts
@@ -187,13 +187,18 @@ export async function collectIgnoreRules(
     // Check if symlink and exclude if requested
     if (!fileStats || (fileStats.isSymbolicLink() && !symlinksEnabled) || fileStats.isFile()) return [];
 
-    // Find ignore files inside this directory
+    // Parse top-level .snyk file inside this directory
+    const topLevelSnykIgnores = parseFileIgnores(`${folder}/${DOTSNYK_FILENAME}`);
+
+    // Find ignore files inside this directory, excluding
+    // paths that are ignored by top-level .snyk exclude rules.
     const localIgnoreFiles = await fg(
       IGNORE_FILES_NAMES.map(i => `*${i}`),
       {
         ...fgOptions,
         cwd: folder,
         followSymbolicLinks: symlinksEnabled,
+        ignore: topLevelSnykIgnores,
       },
     );
     // Read ignore files and merge new patterns

--- a/src/files.ts
+++ b/src/files.ts
@@ -200,7 +200,17 @@ export async function collectIgnoreRules(
     return union(...localIgnoreFiles.map(parseFileIgnores));
   });
   const customRules = await Promise.all(tasks);
-  return union(fileIgnores, ...customRules);
+
+  const rules = union(fileIgnores, ...customRules);
+  const deduplicatedRules: string[] = [];
+
+  for (const rule of rules) {
+    if (!deduplicatedRules.some(existingRule => multimatch(rule, [existingRule]).length > 0)) {
+      deduplicatedRules.push(rule);
+    }
+  }
+
+  return deduplicatedRules;
 }
 
 export function determineBaseDir(paths: string[]): string {

--- a/src/files.ts
+++ b/src/files.ts
@@ -228,12 +228,9 @@ export async function collectFilePolicies(
   const collectedRules = await Promise.all(tasks);
 
   return {
-    excludes: collectedRules.flatMap(policies => policies.excludes),
-    ignores: [
-      // Merge external and collected ignore rules
-      ...fileIgnores,
-      ...collectedRules.flatMap(policies => policies.ignores),
-    ],
+    excludes: union(...collectedRules.map(policies => policies.excludes)),
+    // Merge external and collected ignore rules
+    ignores: union(fileIgnores, ...collectedRules.map(policies => policies.ignores)),
   };
 }
 

--- a/src/interfaces/analysis-options.interface.ts
+++ b/src/interfaces/analysis-options.interface.ts
@@ -46,10 +46,15 @@ export interface AnalyzeFoldersOptions {
   languages?: string[];
 }
 
+export interface FilePolicies {
+  excludes: string[];
+  ignores: string[];
+}
+
 export interface CollectBundleFilesOptions extends AnalyzeFoldersOptions {
   supportedFiles: SupportedFiles;
   baseDir: string;
-  fileIgnores: string[];
+  filePolicies?: FilePolicies;
 }
 
 export interface ReportOptions {

--- a/src/interfaces/analysis-options.interface.ts
+++ b/src/interfaces/analysis-options.interface.ts
@@ -54,7 +54,7 @@ export interface FilePolicies {
 export interface CollectBundleFilesOptions extends AnalyzeFoldersOptions {
   supportedFiles: SupportedFiles;
   baseDir: string;
-  filePolicies?: FilePolicies;
+  filePolicies: FilePolicies;
 }
 
 export interface ReportOptions {

--- a/tests/__snapshots__/files.spec.ts.snap
+++ b/tests/__snapshots__/files.spec.ts.snap
@@ -73,13 +73,6 @@ Array [
     "size": 363,
   },
   Object {
-    "bundlePath": "not/ignored/this_should_be_ignored.jsx",
-    "content": undefined,
-    "filePath": "<basePath>/not/ignored/this_should_be_ignored.jsx",
-    "hash": "3dce2c0456d5f9b6ff64c589047f359b0a7ec390ec1edd20b0070d3399e4e96a",
-    "size": 252,
-  },
-  Object {
     "bundlePath": "not/ignored/this_should_not_be_ignored.java",
     "content": undefined,
     "filePath": "<basePath>/not/ignored/this_should_not_be_ignored.java",

--- a/tests/__snapshots__/files.spec.ts.snap
+++ b/tests/__snapshots__/files.spec.ts.snap
@@ -73,6 +73,13 @@ Array [
     "size": 363,
   },
   Object {
+    "bundlePath": "not/ignored/this_should_be_ignored.jsx",
+    "content": undefined,
+    "filePath": "<basePath>/not/ignored/this_should_be_ignored.jsx",
+    "hash": "3dce2c0456d5f9b6ff64c589047f359b0a7ec390ec1edd20b0070d3399e4e96a",
+    "size": 252,
+  },
+  Object {
     "bundlePath": "not/ignored/this_should_not_be_ignored.java",
     "content": undefined,
     "filePath": "<basePath>/not/ignored/this_should_not_be_ignored.java",

--- a/tests/constants/sample.ts
+++ b/tests/constants/sample.ts
@@ -41,9 +41,6 @@ export const bundleFilePaths = [
   'big-file.js', // <= file size is over the custom MAX_FILE_SIZE
   'routes/index.js',
   'routes/sharks.js',
-  // TODO: This should be ignored for consistency with the .gitignore format (see last rule above),
-  // however we decided to tune down correctness in favour of perfomance for now.
-  'not/ignored/this_should_be_ignored.jsx',
   'not/ignored/this_should_not_be_ignored.java',
 ];
 

--- a/tests/constants/sample.ts
+++ b/tests/constants/sample.ts
@@ -27,6 +27,8 @@ export const bundleFileIgnores = [
   `${sampleProjectPath}/exclude/excluded-folder/**`,
 ];
 
+export const fileIgnoresFixtures = path.resolve(__dirname, '../fixtures/file-ignores');
+
 export const bundleFilePaths = [
   '/.eslintrc.json', // <= we are not running linters in the backend anymore
   '.snyk',

--- a/tests/constants/sample.ts
+++ b/tests/constants/sample.ts
@@ -27,6 +27,26 @@ export const bundleFileIgnores = [
   `${sampleProjectPath}/exclude/excluded-folder/**`,
 ];
 
+export const bundleFilePolicies = {
+  excludes: [
+    `${sampleProjectPath}/**/exclude/excluded-file.js/**`,
+    `${sampleProjectPath}/**/exclude/excluded-file.js`,
+    `${sampleProjectPath}/exclude/excluded-folder/**`,
+  ],
+  ignores: [
+    '**/.git/**',
+    `${sampleProjectPath}/**/mode_nodules/**`,
+    `${sampleProjectPath}/models/**`,
+    `${sampleProjectPath}/**/controllers/**`,
+    `${sampleProjectPath}/**/ignored/**`,
+    `${sampleProjectPath}/**/ignored`,
+    `!${sampleProjectPath}/**/not/ignored/**`,
+    `!${sampleProjectPath}/**/not/ignored`,
+    `${sampleProjectPath}/**/*.jsx/**`,
+    `${sampleProjectPath}/**/*.jsx`,
+  ],
+};
+
 export const fileIgnoresFixtures = path.resolve(__dirname, '../fixtures/file-ignores');
 
 export const bundleFilePaths = [
@@ -41,6 +61,9 @@ export const bundleFilePaths = [
   'big-file.js', // <= file size is over the custom MAX_FILE_SIZE
   'routes/index.js',
   'routes/sharks.js',
+  // TODO: This should be ignored for consistency with the .gitignore format (see last rule above),
+  // however we decided to tune down correctness in favour of perfomance for now.
+  'not/ignored/this_should_be_ignored.jsx',
   'not/ignored/this_should_not_be_ignored.java',
 ];
 

--- a/tests/file-ignores.spec.ts
+++ b/tests/file-ignores.spec.ts
@@ -125,9 +125,13 @@ describe('file ignores', () => {
       expect(ignoreRules).toMatchInlineSnapshot(`
         Array [
           "**/.git/**",
+          "!${collectPath}/sub/**",
+          "!${collectPath}/sub",
           "${collectPath}/snyk-excluded-file.ext/**",
           "${collectPath}/snyk-excluded-file.ext",
           "${collectPath}/**/snyk-excluded-dir/**",
+          "${collectPath}/sub/snyk-excluded-file.js/**",
+          "${collectPath}/sub/snyk-excluded-file.js",
         ]
       `);
     });

--- a/tests/file-ignores.spec.ts
+++ b/tests/file-ignores.spec.ts
@@ -100,5 +100,35 @@ describe('file ignores', () => {
         ]
       `);
     });
+
+    it('from combined files (excluding top-level ignored directories)', async () => {
+      const collectPath = `${fileIgnoresFixtures}/combined`;
+      const ignoreRules = await collectIgnoreRules([collectPath]);
+      expect(ignoreRules).toMatchInlineSnapshot(`
+        Array [
+          "**/.git/**",
+          "${collectPath}/dcignore-root-excluded/**",
+          "${collectPath}/dcignore-root-excluded",
+          "${collectPath}/**/dcignore-deep-excluded/**",
+          "${collectPath}/**/dcignore-deep-excluded",
+          "!${collectPath}/dcignore-root-not-excluded/**",
+          "!${collectPath}/dcignore-root-not-excluded",
+          "!${collectPath}/**/dcignore-deep-not-excluded/**",
+          "!${collectPath}/**/dcignore-deep-not-excluded",
+          "${collectPath}/gitignore-root-excluded/**",
+          "${collectPath}/gitignore-root-excluded",
+          "${collectPath}/**/gitignore-deep-excluded/**",
+          "${collectPath}/**/gitignore-deep-excluded",
+          "!${collectPath}/gitignore-root-not-excluded/**",
+          "!${collectPath}/gitignore-root-not-excluded",
+          "!${collectPath}/**/gitignore-deep-not-excluded/**",
+          "!${collectPath}/**/gitignore-deep-not-excluded",
+          "${collectPath}/snyk-root-excluded/**",
+          "${collectPath}/snyk-root-excluded",
+          "${collectPath}/**/snyk-deep-excluded/**",
+          "${collectPath}/**/snyk-deep-excluded",
+        ]
+      `);
+    });
   });
 });

--- a/tests/file-ignores.spec.ts
+++ b/tests/file-ignores.spec.ts
@@ -34,20 +34,6 @@ describe('file ignores', () => {
 
   describe('collects correct ignore rules', () => {
     it('from dot snyk files', async () => {
-      const collectPath = `${fileIgnoresFixtures}/dot-snyk-excludes/sub`;
-      const ignoreRules = await collectIgnoreRules([collectPath]);
-      expect(ignoreRules).toMatchInlineSnapshot(`
-        Array [
-          "**/.git/**",
-          "${collectPath}/root-excluded/**",
-          "${collectPath}/root-excluded",
-          "${collectPath}/**/deep-excluded/**",
-          "${collectPath}/**/deep-excluded",
-        ]
-      `);
-    });
-
-    it('from dot snyk files (with deduplication)', async () => {
       const collectPath = `${fileIgnoresFixtures}/dot-snyk-excludes`;
       const ignoreRules = await collectIgnoreRules([collectPath]);
       expect(ignoreRules).toMatchInlineSnapshot(`
@@ -101,7 +87,7 @@ describe('file ignores', () => {
       `);
     });
 
-    it('from combined files (excluding top-level ignored directories)', async () => {
+    it('from combined files', async () => {
       const collectPath = `${fileIgnoresFixtures}/combined`;
       const ignoreRules = await collectIgnoreRules([collectPath]);
       expect(ignoreRules).toMatchInlineSnapshot(`
@@ -127,11 +113,13 @@ describe('file ignores', () => {
           "${collectPath}/snyk-root-excluded",
           "${collectPath}/**/snyk-deep-excluded/**",
           "${collectPath}/**/snyk-deep-excluded",
+          "${collectPath}/sub/snyk-nested-excluded/**",
+          "${collectPath}/sub/snyk-nested-excluded",
         ]
       `);
     });
 
-    it('from combined files (overriding negative matches)', async () => {
+    it('from combined files, overriding negative matches', async () => {
       const collectPath = `${fileIgnoresFixtures}/negative-overrides`;
       const ignoreRules = await collectIgnoreRules([collectPath]);
       expect(ignoreRules).toMatchInlineSnapshot(`

--- a/tests/file-ignores.spec.ts
+++ b/tests/file-ignores.spec.ts
@@ -1,7 +1,7 @@
 import 'jest-extended';
 
-import { collectIgnoreRules, parseFileIgnores } from '../src/files';
-import { sampleProjectPath, fileIgnoresFixtures, bundleFileIgnores } from './constants/sample';
+import { collectFilePolicies, parseFileIgnores } from '../src/files';
+import { sampleProjectPath, fileIgnoresFixtures, bundleFileIgnores, bundleFilePolicies } from './constants/sample';
 
 describe('file ignores', () => {
   describe('sample-repo', () => {
@@ -27,112 +27,111 @@ describe('file ignores', () => {
     });
 
     it('collects ignore rules', async () => {
-      const ignoreRules = await collectIgnoreRules([sampleProjectPath]);
-      expect(ignoreRules).toEqual(bundleFileIgnores);
+      const ignoreRules = await collectFilePolicies([sampleProjectPath]);
+      expect(ignoreRules).toEqual(bundleFilePolicies);
     });
   });
 
   describe('collects correct ignore rules', () => {
     it('from dot snyk files', async () => {
       const collectPath = `${fileIgnoresFixtures}/dot-snyk-excludes`;
-      const ignoreRules = await collectIgnoreRules([collectPath]);
+      const ignoreRules = await collectFilePolicies([collectPath]);
       expect(ignoreRules).toMatchInlineSnapshot(`
-        Array [
-          "**/.git/**",
-          "${collectPath}/root-excluded/**",
-          "${collectPath}/root-excluded",
-          "${collectPath}/root-excluded-contents/**",
-          "${collectPath}/**/deep-excluded/**",
-          "${collectPath}/**/deep-excluded",
-          "${collectPath}/**/deep-excluded-contents/**",
-          "${collectPath}/sub/root-excluded/**",
-          "${collectPath}/sub/root-excluded",
-        ]
+        Object {
+          "excludes": Array [
+            "${collectPath}/root-excluded/**",
+            "${collectPath}/root-excluded",
+            "${collectPath}/root-excluded-contents/**",
+            "${collectPath}/**/deep-excluded/**",
+            "${collectPath}/**/deep-excluded",
+            "${collectPath}/**/deep-excluded-contents/**",
+            "${collectPath}/sub/root-excluded/**",
+            "${collectPath}/sub/root-excluded",
+            "${collectPath}/sub/**/deep-excluded/**",
+            "${collectPath}/sub/**/deep-excluded",
+          ],
+          "ignores": Array [
+            "**/.git/**",
+          ],
+        }
       `);
     });
 
     it('from dot dcignore file', async () => {
       const collectPath = `${fileIgnoresFixtures}/dot-dcignore-rules`;
-      const ignoreRules = await collectIgnoreRules([collectPath]);
+      const ignoreRules = await collectFilePolicies([collectPath]);
       expect(ignoreRules).toMatchInlineSnapshot(`
-        Array [
-          "**/.git/**",
-          "${collectPath}/root-excluded/**",
-          "${collectPath}/root-excluded",
-          "${collectPath}/root-excluded-contents/**",
-          "${collectPath}/**/deep-excluded/**",
-          "${collectPath}/**/deep-excluded",
-          "${collectPath}/**/deep-excluded-contents/**",
-          "!${collectPath}/not/deep-excluded/**",
-          "!${collectPath}/not/deep-excluded",
-        ]
+        Object {
+          "excludes": Array [],
+          "ignores": Array [
+            "**/.git/**",
+            "${collectPath}/root-excluded/**",
+            "${collectPath}/root-excluded",
+            "${collectPath}/root-excluded-contents/**",
+            "${collectPath}/**/deep-excluded/**",
+            "${collectPath}/**/deep-excluded",
+            "${collectPath}/**/deep-excluded-contents/**",
+            "!${collectPath}/not/deep-excluded/**",
+            "!${collectPath}/not/deep-excluded",
+          ],
+        }
       `);
     });
 
     it('from dot gitignore file', async () => {
       const collectPath = `${fileIgnoresFixtures}/dot-gitignore-rules`;
-      const ignoreRules = await collectIgnoreRules([collectPath]);
+      const ignoreRules = await collectFilePolicies([collectPath]);
       expect(ignoreRules).toMatchInlineSnapshot(`
-        Array [
-          "**/.git/**",
-          "${collectPath}/root-excluded/**",
-          "${collectPath}/root-excluded",
-          "${collectPath}/root-excluded-contents/**",
-          "${collectPath}/**/deep-excluded/**",
-          "${collectPath}/**/deep-excluded",
-          "${collectPath}/**/deep-excluded-contents/**",
-          "!${collectPath}/not/deep-excluded/**",
-          "!${collectPath}/not/deep-excluded",
-        ]
+        Object {
+          "excludes": Array [],
+          "ignores": Array [
+            "**/.git/**",
+            "${collectPath}/root-excluded/**",
+            "${collectPath}/root-excluded",
+            "${collectPath}/root-excluded-contents/**",
+            "${collectPath}/**/deep-excluded/**",
+            "${collectPath}/**/deep-excluded",
+            "${collectPath}/**/deep-excluded-contents/**",
+            "!${collectPath}/not/deep-excluded/**",
+            "!${collectPath}/not/deep-excluded",
+          ],
+        }
       `);
     });
 
     it('from combined files', async () => {
       const collectPath = `${fileIgnoresFixtures}/combined`;
-      const ignoreRules = await collectIgnoreRules([collectPath]);
+      const ignoreRules = await collectFilePolicies([collectPath]);
       expect(ignoreRules).toMatchInlineSnapshot(`
-        Array [
-          "**/.git/**",
-          "${collectPath}/dcignore-root-excluded/**",
-          "${collectPath}/dcignore-root-excluded",
-          "${collectPath}/**/dcignore-deep-excluded/**",
-          "${collectPath}/**/dcignore-deep-excluded",
-          "!${collectPath}/dcignore-root-not-excluded/**",
-          "!${collectPath}/dcignore-root-not-excluded",
-          "!${collectPath}/**/dcignore-deep-not-excluded/**",
-          "!${collectPath}/**/dcignore-deep-not-excluded",
-          "${collectPath}/gitignore-root-excluded/**",
-          "${collectPath}/gitignore-root-excluded",
-          "${collectPath}/**/gitignore-deep-excluded/**",
-          "${collectPath}/**/gitignore-deep-excluded",
-          "!${collectPath}/gitignore-root-not-excluded/**",
-          "!${collectPath}/gitignore-root-not-excluded",
-          "!${collectPath}/**/gitignore-deep-not-excluded/**",
-          "!${collectPath}/**/gitignore-deep-not-excluded",
-          "${collectPath}/snyk-root-excluded/**",
-          "${collectPath}/snyk-root-excluded",
-          "${collectPath}/**/snyk-deep-excluded/**",
-          "${collectPath}/**/snyk-deep-excluded",
-          "${collectPath}/sub/snyk-nested-excluded/**",
-          "${collectPath}/sub/snyk-nested-excluded",
-        ]
-      `);
-    });
-
-    it('from combined files, overriding negative matches', async () => {
-      const collectPath = `${fileIgnoresFixtures}/negative-overrides`;
-      const ignoreRules = await collectIgnoreRules([collectPath]);
-      expect(ignoreRules).toMatchInlineSnapshot(`
-        Array [
-          "**/.git/**",
-          "!${collectPath}/sub/**",
-          "!${collectPath}/sub",
-          "${collectPath}/snyk-excluded-file.ext/**",
-          "${collectPath}/snyk-excluded-file.ext",
-          "${collectPath}/**/snyk-excluded-dir/**",
-          "${collectPath}/sub/snyk-excluded-file.js/**",
-          "${collectPath}/sub/snyk-excluded-file.js",
-        ]
+        Object {
+          "excludes": Array [
+            "${collectPath}/snyk-root-excluded/**",
+            "${collectPath}/snyk-root-excluded",
+            "${collectPath}/**/snyk-deep-excluded/**",
+            "${collectPath}/**/snyk-deep-excluded",
+            "${collectPath}/sub/snyk-nested-excluded/**",
+            "${collectPath}/sub/snyk-nested-excluded",
+          ],
+          "ignores": Array [
+            "**/.git/**",
+            "${collectPath}/dcignore-root-excluded/**",
+            "${collectPath}/dcignore-root-excluded",
+            "${collectPath}/**/dcignore-deep-excluded/**",
+            "${collectPath}/**/dcignore-deep-excluded",
+            "!${collectPath}/dcignore-root-not-excluded/**",
+            "!${collectPath}/dcignore-root-not-excluded",
+            "!${collectPath}/**/dcignore-deep-not-excluded/**",
+            "!${collectPath}/**/dcignore-deep-not-excluded",
+            "${collectPath}/gitignore-root-excluded/**",
+            "${collectPath}/gitignore-root-excluded",
+            "${collectPath}/**/gitignore-deep-excluded/**",
+            "${collectPath}/**/gitignore-deep-excluded",
+            "!${collectPath}/gitignore-root-not-excluded/**",
+            "!${collectPath}/gitignore-root-not-excluded",
+            "!${collectPath}/**/gitignore-deep-not-excluded/**",
+            "!${collectPath}/**/gitignore-deep-not-excluded",
+          ],
+        }
       `);
     });
   });

--- a/tests/file-ignores.spec.ts
+++ b/tests/file-ignores.spec.ts
@@ -64,5 +64,23 @@ describe('file ignores', () => {
         ]
       `);
     });
+
+    it('from dot dcignore file', async () => {
+      const collectPath = `${fileIgnoresFixtures}/dot-dcignore-rules`;
+      const ignoreRules = await collectIgnoreRules([collectPath]);
+      expect(ignoreRules).toMatchInlineSnapshot(`
+      Array [
+        "**/.git/**",
+        "${collectPath}/root-excluded/**",
+        "${collectPath}/root-excluded",
+        "${collectPath}/root-excluded-contents/**",
+        "${collectPath}/**/deep-excluded/**",
+        "${collectPath}/**/deep-excluded",
+        "${collectPath}/**/deep-excluded-contents/**",
+        "!${collectPath}/not/deep-excluded/**",
+        "!${collectPath}/not/deep-excluded",
+      ]
+    `);
+    });
   });
 });

--- a/tests/file-ignores.spec.ts
+++ b/tests/file-ignores.spec.ts
@@ -47,7 +47,7 @@ describe('file ignores', () => {
       `);
     });
 
-    it('from dot snyk files', async () => {
+    it('from dot snyk files (with deduplication)', async () => {
       const collectPath = `${fileIgnoresFixtures}/dot-snyk-excludes`;
       const ignoreRules = await collectIgnoreRules([collectPath]);
       expect(ignoreRules).toMatchInlineSnapshot(`
@@ -61,8 +61,6 @@ describe('file ignores', () => {
           "${collectPath}/**/deep-excluded-contents/**",
           "${collectPath}/sub/root-excluded/**",
           "${collectPath}/sub/root-excluded",
-          "${collectPath}/sub/**/deep-excluded/**",
-          "${collectPath}/sub/**/deep-excluded",
         ]
       `);
     });

--- a/tests/file-ignores.spec.ts
+++ b/tests/file-ignores.spec.ts
@@ -130,5 +130,18 @@ describe('file ignores', () => {
         ]
       `);
     });
+
+    it('from combined files (overriding negative matches)', async () => {
+      const collectPath = `${fileIgnoresFixtures}/negative-overrides`;
+      const ignoreRules = await collectIgnoreRules([collectPath]);
+      expect(ignoreRules).toMatchInlineSnapshot(`
+        Array [
+          "**/.git/**",
+          "${collectPath}/snyk-excluded-file.ext/**",
+          "${collectPath}/snyk-excluded-file.ext",
+          "${collectPath}/**/snyk-excluded-dir/**",
+        ]
+      `);
+    });
   });
 });

--- a/tests/file-ignores.spec.ts
+++ b/tests/file-ignores.spec.ts
@@ -69,18 +69,36 @@ describe('file ignores', () => {
       const collectPath = `${fileIgnoresFixtures}/dot-dcignore-rules`;
       const ignoreRules = await collectIgnoreRules([collectPath]);
       expect(ignoreRules).toMatchInlineSnapshot(`
-      Array [
-        "**/.git/**",
-        "${collectPath}/root-excluded/**",
-        "${collectPath}/root-excluded",
-        "${collectPath}/root-excluded-contents/**",
-        "${collectPath}/**/deep-excluded/**",
-        "${collectPath}/**/deep-excluded",
-        "${collectPath}/**/deep-excluded-contents/**",
-        "!${collectPath}/not/deep-excluded/**",
-        "!${collectPath}/not/deep-excluded",
-      ]
-    `);
+        Array [
+          "**/.git/**",
+          "${collectPath}/root-excluded/**",
+          "${collectPath}/root-excluded",
+          "${collectPath}/root-excluded-contents/**",
+          "${collectPath}/**/deep-excluded/**",
+          "${collectPath}/**/deep-excluded",
+          "${collectPath}/**/deep-excluded-contents/**",
+          "!${collectPath}/not/deep-excluded/**",
+          "!${collectPath}/not/deep-excluded",
+        ]
+      `);
+    });
+
+    it('from dot gitignore file', async () => {
+      const collectPath = `${fileIgnoresFixtures}/dot-gitignore-rules`;
+      const ignoreRules = await collectIgnoreRules([collectPath]);
+      expect(ignoreRules).toMatchInlineSnapshot(`
+        Array [
+          "**/.git/**",
+          "${collectPath}/root-excluded/**",
+          "${collectPath}/root-excluded",
+          "${collectPath}/root-excluded-contents/**",
+          "${collectPath}/**/deep-excluded/**",
+          "${collectPath}/**/deep-excluded",
+          "${collectPath}/**/deep-excluded-contents/**",
+          "!${collectPath}/not/deep-excluded/**",
+          "!${collectPath}/not/deep-excluded",
+        ]
+      `);
     });
   });
 });

--- a/tests/file-ignores.spec.ts
+++ b/tests/file-ignores.spec.ts
@@ -1,0 +1,70 @@
+import 'jest-extended';
+
+import { collectIgnoreRules, parseFileIgnores } from '../src/files';
+import { sampleProjectPath, fileIgnoresFixtures, bundleFileIgnores } from './constants/sample';
+
+describe('file ignores', () => {
+  describe('sample-repo', () => {
+    it('parses dc ignore file', () => {
+      const patterns = parseFileIgnores(`${sampleProjectPath}/.dcignore`);
+      expect(patterns).toEqual(bundleFileIgnores.slice(1, 10));
+    });
+
+    it('parses dot snyk file', () => {
+      const patterns = parseFileIgnores(`${sampleProjectPath}/.snyk`);
+      expect(patterns).toEqual(bundleFileIgnores.slice(10));
+    });
+
+    it('parses dot snyk file with only one field', () => {
+      const patterns = parseFileIgnores(`${sampleProjectPath}/exclude/.snyk`);
+      expect(patterns).toEqual(bundleFileIgnores.slice(12));
+    });
+
+    it('fails to parse dot snyk file with invalid field', () => {
+      expect(() => parseFileIgnores(`${sampleProjectPath}/invalid-dot-snyk/.snyk.invalid`)).toThrow(
+        'Please make sure ignore file follows correct syntax',
+      );
+    });
+
+    it('collects ignore rules', async () => {
+      const ignoreRules = await collectIgnoreRules([sampleProjectPath]);
+      expect(ignoreRules).toEqual(bundleFileIgnores);
+    });
+  });
+
+  describe('collects correct ignore rules', () => {
+    it('from dot snyk files', async () => {
+      const collectPath = `${fileIgnoresFixtures}/dot-snyk-excludes/sub`;
+      const ignoreRules = await collectIgnoreRules([collectPath]);
+      expect(ignoreRules).toMatchInlineSnapshot(`
+        Array [
+          "**/.git/**",
+          "${collectPath}/root-excluded/**",
+          "${collectPath}/root-excluded",
+          "${collectPath}/**/deep-excluded/**",
+          "${collectPath}/**/deep-excluded",
+        ]
+      `);
+    });
+
+    it('from dot snyk files', async () => {
+      const collectPath = `${fileIgnoresFixtures}/dot-snyk-excludes`;
+      const ignoreRules = await collectIgnoreRules([collectPath]);
+      expect(ignoreRules).toMatchInlineSnapshot(`
+        Array [
+          "**/.git/**",
+          "${collectPath}/root-excluded/**",
+          "${collectPath}/root-excluded",
+          "${collectPath}/root-excluded-contents/**",
+          "${collectPath}/**/deep-excluded/**",
+          "${collectPath}/**/deep-excluded",
+          "${collectPath}/**/deep-excluded-contents/**",
+          "${collectPath}/sub/root-excluded/**",
+          "${collectPath}/sub/root-excluded",
+          "${collectPath}/sub/**/deep-excluded/**",
+          "${collectPath}/sub/**/deep-excluded",
+        ]
+      `);
+    });
+  });
+});

--- a/tests/files.spec.ts
+++ b/tests/files.spec.ts
@@ -3,11 +3,9 @@ import * as nodePath from 'path';
 import 'jest-extended';
 
 import {
-  collectIgnoreRules,
   collectBundleFiles,
   prepareExtendingBundle,
   composeFilePayloads,
-  parseFileIgnores,
   getFileInfo,
   getBundleFilePath,
   resolveBundleFilePath,
@@ -17,29 +15,6 @@ import { FileInfo } from '../src/interfaces/files.interface';
 import { sampleProjectPath, supportedFiles, bundleFiles, bundleFilesFull, bundleFileIgnores } from './constants/sample';
 
 describe('files', () => {
-  it('parse dc ignore file', () => {
-    const patterns = parseFileIgnores(`${sampleProjectPath}/.dcignore`);
-    expect(patterns).toEqual(bundleFileIgnores.slice(1, 10));
-  });
-  it('parse dot snyk file', () => {
-    const patterns = parseFileIgnores(`${sampleProjectPath}/.snyk`);
-    expect(patterns).toEqual(bundleFileIgnores.slice(10));
-  });
-  it('parse dot snyk file with only one field', () => {
-    const patterns = parseFileIgnores(`${sampleProjectPath}/exclude/.snyk`);
-    expect(patterns).toEqual(bundleFileIgnores.slice(12));
-  });
-  it('fails to parse dot snyk file with invalid field', () => {
-    expect(() => parseFileIgnores(`${sampleProjectPath}/invalid-dot-snyk/.snyk.invalid`)).toThrow(
-      'Please make sure ignore file follows correct syntax',
-    );
-  });
-
-  it('collect ignore rules', async () => {
-    const ignoreRules = await collectIgnoreRules([sampleProjectPath]);
-    expect(ignoreRules).toEqual(bundleFileIgnores);
-  });
-
   it('collect bundle files', async () => {
     // TODO: We should introduce some performance test using a big enough repo to avoid flaky results
     const collector = collectBundleFiles({

--- a/tests/files.spec.ts
+++ b/tests/files.spec.ts
@@ -92,6 +92,10 @@ describe('files', () => {
       baseDir: sampleProjectPath,
       paths: folders,
       supportedFiles,
+      filePolicies: {
+        excludes: [],
+        ignores: [],
+      },
     });
     const smallFiles: FileInfo[] = [];
     const skippedOversizedFiles: string[] = [];

--- a/tests/fixtures/file-ignores/combined/.dcignore
+++ b/tests/fixtures/file-ignores/combined/.dcignore
@@ -1,0 +1,4 @@
+/dcignore-root-excluded
+dcignore-deep-excluded
+!/dcignore-root-not-excluded
+!dcignore-deep-not-excluded

--- a/tests/fixtures/file-ignores/combined/.gitignore
+++ b/tests/fixtures/file-ignores/combined/.gitignore
@@ -1,0 +1,4 @@
+/gitignore-root-excluded
+gitignore-deep-excluded
+!/gitignore-root-not-excluded
+!gitignore-deep-not-excluded

--- a/tests/fixtures/file-ignores/combined/.snyk
+++ b/tests/fixtures/file-ignores/combined/.snyk
@@ -1,0 +1,4 @@
+exclude:
+  global:
+    - /snyk-root-excluded
+    - snyk-deep-excluded

--- a/tests/fixtures/file-ignores/combined/snyk-root-excluded/.gitignore
+++ b/tests/fixtures/file-ignores/combined/snyk-root-excluded/.gitignore
@@ -1,0 +1,3 @@
+# We expect this rule not to be collected,
+# since the parent dir is excluded by the root rules.
+!/snyk-deep-excluded

--- a/tests/fixtures/file-ignores/combined/sub/.snyk
+++ b/tests/fixtures/file-ignores/combined/sub/.snyk
@@ -1,0 +1,3 @@
+exclude:
+  global:
+    - /snyk-nested-excluded

--- a/tests/fixtures/file-ignores/combined/sub/snyk-deep-excluded/.gitignore
+++ b/tests/fixtures/file-ignores/combined/sub/snyk-deep-excluded/.gitignore
@@ -1,0 +1,3 @@
+# We expect this rule not to be collected,
+# since the parent dir is excluded by the root rules.
+!/snyk-deep-excluded/test.js

--- a/tests/fixtures/file-ignores/combined/sub/snyk-nested-excluded/.gitignore
+++ b/tests/fixtures/file-ignores/combined/sub/snyk-nested-excluded/.gitignore
@@ -1,0 +1,3 @@
+# We expect this rule not to be collected,
+# since the parent dir is excluded by rules from a nested .snyk file.
+!/snyk-nested-excluded/test.js

--- a/tests/fixtures/file-ignores/dot-dcignore-rules/.dcignore
+++ b/tests/fixtures/file-ignores/dot-dcignore-rules/.dcignore
@@ -1,0 +1,5 @@
+/root-excluded
+/root-excluded-contents/
+deep-excluded
+deep-excluded-contents/
+!/not/deep-excluded

--- a/tests/fixtures/file-ignores/dot-gitignore-rules/.gitignore
+++ b/tests/fixtures/file-ignores/dot-gitignore-rules/.gitignore
@@ -1,0 +1,5 @@
+/root-excluded
+/root-excluded-contents/
+deep-excluded
+deep-excluded-contents/
+!/not/deep-excluded

--- a/tests/fixtures/file-ignores/dot-snyk-excludes/.snyk
+++ b/tests/fixtures/file-ignores/dot-snyk-excludes/.snyk
@@ -1,0 +1,6 @@
+exclude:
+  code:
+    - /root-excluded
+    - /root-excluded-contents/
+    - deep-excluded
+    - deep-excluded-contents/

--- a/tests/fixtures/file-ignores/dot-snyk-excludes/sub/.snyk
+++ b/tests/fixtures/file-ignores/dot-snyk-excludes/sub/.snyk
@@ -1,0 +1,4 @@
+exclude:
+  code:
+    - /root-excluded
+    - deep-excluded

--- a/tests/fixtures/file-ignores/negative-overrides/.gitignore
+++ b/tests/fixtures/file-ignores/negative-overrides/.gitignore
@@ -1,2 +1,3 @@
 !/snyk-excluded-file.ext
 !/snyk-excluded-dir/
+!/sub

--- a/tests/fixtures/file-ignores/negative-overrides/.gitignore
+++ b/tests/fixtures/file-ignores/negative-overrides/.gitignore
@@ -1,3 +1,4 @@
 !/snyk-excluded-file.ext
 !/snyk-excluded-dir/
 !/sub
+!/gitignore-unexcluded-dir

--- a/tests/fixtures/file-ignores/negative-overrides/.gitignore
+++ b/tests/fixtures/file-ignores/negative-overrides/.gitignore
@@ -1,0 +1,2 @@
+!/snyk-excluded-file.ext
+!/snyk-excluded-dir/

--- a/tests/fixtures/file-ignores/negative-overrides/.snyk
+++ b/tests/fixtures/file-ignores/negative-overrides/.snyk
@@ -2,3 +2,4 @@ exclude:
   global:
     - /snyk-excluded-file.ext
     - snyk-excluded-dir/
+    - /sub/snyk-excluded-file.js

--- a/tests/fixtures/file-ignores/negative-overrides/.snyk
+++ b/tests/fixtures/file-ignores/negative-overrides/.snyk
@@ -3,3 +3,4 @@ exclude:
     - /snyk-excluded-file.ext
     - snyk-excluded-dir/
     - /sub/snyk-excluded-file.js
+    - /gitignore-unexcluded-dir/snyk-excluded-dir

--- a/tests/fixtures/file-ignores/negative-overrides/.snyk
+++ b/tests/fixtures/file-ignores/negative-overrides/.snyk
@@ -1,0 +1,4 @@
+exclude:
+  global:
+    - /snyk-excluded-file.ext
+    - snyk-excluded-dir/


### PR DESCRIPTION
- [x] Ready for review
- [x] Linked to Jira ticket

#### What does this PR do?

Addresses logic bugs in the behaviour of file excludes and ignore rules.

Current (incorrect) behaviour:
- it collects all exclude/ignore rules from all supported files in the directory, including from directories excluded by the root-level .snyk file
	- i.e. if a directory `sub` is excluded by the top-level `.snyk` file, we still traverse it and collect any supported ignore files, which is unexpected and wrong behaviour - excluded directories should not be traversed at all.
- it applies negative match rules, which in some cases can override the .snyk exclude rules
	- i.e. if a `.snyk` exclude is defined for a directory or file `sub`, and there is a negative match for the same directory or file in the `.gitignore` file (`!sub`), `sub` will not be excluded as expected.

In short, these fixes aim to more strictly enforce file and directory exclusions defined in the `.snyk` file.

The way it works post fixes:
- Collect exclusion rules from all `.snyk` files in directory, if present
- Collect ignore rules from all other supported ignore files (`.dcignore`, `.gitignore`), except the ones found in paths excluded from the root `.snyk` file
- Return separate sets of rules for excludes and ignores
- Apply combined positive ignore rules to first supported files collection pass
- Apply only exclude rules to second file pass for negative pattern collection

This ensures that `.snyk` exclude rules always get apply, and cannot be overridden by negative ignore rules.

Performing a simple benchmark with 25 iterations of ignore rule collection against Registry, I did not find any significant performance difference between the old and new implementations.
As all local benchmarks it should be taken with a grain of salt, however I do not expect any noticeable slowdown of the collection, and depending on the number of files and exclude rules, customers might see a performance improvement as we no longer collect and parse ignore rules from files in excluded directories.

```
describe('performance benchmark', () => {
  it.each([
    ['new implementation', collectFilePolicies],
    ['old implementation', collectIgnoreRules],
  ])(`%s`, async (implementationType, collectIgnoreRulesFn) => {
    const collectPath = '/Users/alex/Projects/registry';

    const timings: number[] = [];

    for (let i = 0; i < 25; i++) {
      const t1 = Date.now();
      await collectIgnoreRulesFn([collectPath]);
      const t2 = Date.now();
      const time = t2 - t1;

      timings.push(time);
    }

    const average = timings.reduce((a, b) => a + b, 0) / timings.length;
    console.log(`Average time for ${implementationType}: ${average} milliseconds.`);
  });
});
```

Results:
```
  performance benchmark
    ✓ new implementation (31313 ms)
    ✓ old implementation (29438 ms)

Average time for new implementation: 1252.12 milliseconds.
Average time for old implementation: 1177.36 milliseconds.
```

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

https://snyksec.atlassian.net/browse/ZEN-588
https://snyksec.atlassian.net/browse/ZEN-630
https://snyksec.atlassian.net/browse/ZEN-773

#### Screenshots

#### Additional questions
