### PR TITLE
feat: add routing to GW option for sast

### DIFF
--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -1,0 +1,13 @@
+export function getURL(baseURL: string, path: string, orgId?: string): string {
+  if (routeToGateway(baseURL)) {
+    if (!orgId) {
+      throw new Error('Org is required for this operation');
+    }
+    return `${baseURL}/hidden/orgs/${orgId}/code${path}`;
+  }
+  return `${baseURL}${path}`;
+}
+
+function routeToGateway(baseURL: string): boolean {
+  return baseURL.includes('snykgov.io');
+}

--- a/tests/httpUtils.spec.ts
+++ b/tests/httpUtils.spec.ts
@@ -1,0 +1,33 @@
+import { getURL } from "../src/utils/httpUtils";
+
+describe('getURL', () => {
+    it('should return base + path if not fedramp', () => {
+        const base = 'api.dev.snyk.io';
+        const path = '/analysis';
+
+        const result = getURL(base, path);
+
+        expect(result).toEqual(base+path);
+    });
+
+    it('should return base + org routing + path if fedramp', () => {
+        const base = 'api.snykgov.io';
+        const path = '/analysis';
+        const orgId = '1-2-3-4'
+
+        const result = getURL(base, path, orgId);
+
+        expect(result).toEqual(base+'/hidden/orgs/'+orgId+'/code'+path);
+    });
+
+    it('should throw an error if fedramp and org is missing', () => {
+        const base = 'api.snykgov.io';
+        const path = '/analysis';
+
+        try {
+            const result = getURL(base, path);
+        } catch (err) {
+            expect(err).toBeDefined();
+        }
+    });
+});

--- a/tests/httpUtils.spec.ts
+++ b/tests/httpUtils.spec.ts
@@ -1,33 +1,33 @@
-import { getURL } from "../src/utils/httpUtils";
+import { getURL } from '../src/utils/httpUtils';
 
 describe('getURL', () => {
-    it('should return base + path if not fedramp', () => {
-        const base = 'api.dev.snyk.io';
-        const path = '/analysis';
+  it('should return base + path if not fedramp', () => {
+    const base = 'api.dev.snyk.io';
+    const path = '/analysis';
 
-        const result = getURL(base, path);
+    const result = getURL(base, path);
 
-        expect(result).toEqual(base+path);
-    });
+    expect(result).toEqual(base + path);
+  });
 
-    it('should return base + org routing + path if fedramp', () => {
-        const base = 'api.snykgov.io';
-        const path = '/analysis';
-        const orgId = '1-2-3-4'
+  it('should return base + org routing + path if fedramp', () => {
+    const base = 'api.snykgov.io';
+    const path = '/analysis';
+    const orgId = '1-2-3-4';
 
-        const result = getURL(base, path, orgId);
+    const result = getURL(base, path, orgId);
 
-        expect(result).toEqual(base+'/hidden/orgs/'+orgId+'/code'+path);
-    });
+    expect(result).toEqual(base + '/hidden/orgs/' + orgId + '/code' + path);
+  });
 
-    it('should throw an error if fedramp and org is missing', () => {
-        const base = 'api.snykgov.io';
-        const path = '/analysis';
+  it('should throw an error if fedramp and org is missing', () => {
+    const base = 'api.snykgov.io';
+    const path = '/analysis';
 
-        try {
-            const result = getURL(base, path);
-        } catch (err) {
-            expect(err).toBeDefined();
-        }
-    });
+    try {
+      const result = getURL(base, path);
+    } catch (err) {
+      expect(err).toBeDefined();
+    }
+  });
 });

--- a/tests/httpUtils.spec.ts
+++ b/tests/httpUtils.spec.ts
@@ -24,10 +24,6 @@ describe('getURL', () => {
     const base = 'api.snykgov.io';
     const path = '/analysis';
 
-    try {
-      const result = getURL(base, path);
-    } catch (err) {
-      expect(err).toBeDefined();
-    }
+    expect(() => getURL(base, path)).toThrowError('Org is required for this operation');
   });
 });


### PR DESCRIPTION
- [X] Ready for review
- [X] Linked to Jira ticket - https://snyksec.atlassian.net/browse/PUL2-801

#### What does this PR do?
Adding logic to route to gateway instead of the deeproxy service

#### Where should the reviewer start?
src/utils/httpUtils.ts

#### How should this be manually tested?
You can run the tests

#### Any background context you want to provide?
For a temporary stage where some Deeproxy changes only deployed to FedRAMP we add this logic to use the new Deeproxy arch' in the FedRAMP clusters. 
When the changes are deployed to all the clusters we can use this new logic as default logic.

#### Screenshots

#### Additional questions
