### PR TITLE
feat: add error handling for limit errors

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -3,26 +3,28 @@ import pick from 'lodash.pick';
 import { gzip } from 'zlib';
 import { promisify } from 'util';
 
-import { ErrorCodes, GenericErrorTypes, DEFAULT_ERROR_MESSAGES, MAX_RETRY_ATTEMPTS } from './constants';
+import { DEFAULT_ERROR_MESSAGES, ErrorCodes, GenericErrorTypes, MAX_RETRY_ATTEMPTS } from './constants';
 
 import { BundleFiles, SupportedFiles } from './interfaces/files.interface';
 import { AnalysisResult, ReportResult } from './interfaces/analysis-result.interface';
 import { FailedResponse, makeRequest, Payload } from './needle';
 import {
-  AnalysisOptions,
   AnalysisContext,
+  AnalysisOptions,
   ReportOptions,
   ScmReportOptions,
 } from './interfaces/analysis-options.interface';
-import { getURL } from './utils/httpUtils';
+import { generateJsonApiError, getURL, isJsonApiErrors } from './utils/httpUtils';
 
 type ResultSuccess<T> = { type: 'success'; value: T };
-type ResultError<E> = {
+
+export type ResultError<E> = {
   type: 'error';
   error: {
-    statusCode: E;
+    statusCode: E | number;
     statusText: string;
     apiName: string;
+    detail?: string | undefined;
   };
 };
 
@@ -41,24 +43,26 @@ export interface ConnectionOptions {
 // The trick to typecast union type alias
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function isSubsetErrorCode<T>(code: any, messages: { [c: number]: string }): code is T {
-  if (code in messages) {
-    return true;
-  }
-  return false;
+  return code in messages;
 }
 
 function generateError<E>(
   errorCode: number,
   messages: { [c: number]: string },
   apiName: string,
-  error?: string,
+  errorMessage?: string,
+  errors?: unknown,
 ): ResultError<E> {
+  if (isJsonApiErrors(errors)) {
+    return generateJsonApiError<E>(errors, errorCode, apiName);
+  }
+
   if (!isSubsetErrorCode<E>(errorCode, messages)) {
-    throw { errorCode, messages, apiName };
+    throw { statusCode: errorCode, statusText: errorMessage || 'unknown error occurred', apiName };
   }
 
   const statusCode = errorCode;
-  const statusText = error ?? messages[errorCode];
+  const statusText = errorMessage ?? messages[errorCode];
 
   return {
     type: 'error',
@@ -92,8 +96,7 @@ interface StartSessionOptions {
 export async function compressAndEncode(payload: unknown): Promise<Buffer> {
   // encode payload and compress;
   const deflate = promisify(gzip);
-  const compressedPayload = await deflate(Buffer.from(JSON.stringify(payload)).toString('base64'));
-  return compressedPayload;
+  return await deflate(Buffer.from(JSON.stringify(payload)).toString('base64'));
 }
 
 export function startSession(options: StartSessionOptions): StartSessionResponseDto {
@@ -271,7 +274,13 @@ export async function createBundle(
   if (res.success) {
     return { type: 'success', value: res.body };
   }
-  return generateError<CreateBundleErrorCodes>(res.errorCode, CREATE_BUNDLE_ERROR_MESSAGES, 'createBundle');
+  return generateError<CreateBundleErrorCodes>(
+    res.errorCode,
+    CREATE_BUNDLE_ERROR_MESSAGES,
+    'createBundle',
+    undefined,
+    res.errors,
+  );
 }
 
 export type CheckBundleErrorCodes =
@@ -359,7 +368,13 @@ export async function extendBundle(
     isJson: false,
   });
   if (res.success) return { type: 'success', value: res.body };
-  return generateError<ExtendBundleErrorCodes>(res.errorCode, EXTEND_BUNDLE_ERROR_MESSAGES, 'extendBundle');
+  return generateError<ExtendBundleErrorCodes>(
+    res.errorCode,
+    EXTEND_BUNDLE_ERROR_MESSAGES,
+    'extendBundle',
+    undefined,
+    res.errors,
+  );
 }
 
 // eslint-disable-next-line no-shadow
@@ -431,8 +446,16 @@ export async function getAnalysis(
   };
 
   const res = await makeRequest<GetAnalysisResponseDto>(config);
-  if (res.success) return { type: 'success', value: res.body };
-  return generateError<GetAnalysisErrorCodes>(res.errorCode, GET_ANALYSIS_ERROR_MESSAGES, 'getAnalysis');
+  if (res.success) {
+    return { type: 'success', value: res.body };
+  }
+  return generateError<GetAnalysisErrorCodes>(
+    res.errorCode,
+    GET_ANALYSIS_ERROR_MESSAGES,
+    'getAnalysis',
+    undefined,
+    res.errors,
+  );
 }
 
 export type ReportErrorCodes =

--- a/src/http.ts
+++ b/src/http.ts
@@ -208,7 +208,7 @@ export async function getFilters(
   if (res.success) {
     return { type: 'success', value: res.body };
   }
-  return generateError<GenericErrorTypes>(res.errorCode, GENERIC_ERROR_MESSAGES, apiName);
+  return generateError<GenericErrorTypes>(res.errorCode, GENERIC_ERROR_MESSAGES, apiName, undefined, res.jsonApiError);
 }
 
 function commonHttpHeaders(options: ConnectionOptions) {
@@ -319,7 +319,13 @@ export async function checkBundle(options: CheckBundleOptions): Promise<Result<R
   });
 
   if (res.success) return { type: 'success', value: res.body };
-  return generateError<CheckBundleErrorCodes>(res.errorCode, CHECK_BUNDLE_ERROR_MESSAGES, 'checkBundle');
+  return generateError<CheckBundleErrorCodes>(
+    res.errorCode,
+    CHECK_BUNDLE_ERROR_MESSAGES,
+    'checkBundle',
+    undefined,
+    res.jsonApiError,
+  );
 }
 
 export type ExtendBundleErrorCodes =
@@ -532,7 +538,13 @@ export async function initReport(options: UploadReportOptions): Promise<Result<s
 
   const res = await makeRequest<InitUploadResponseDto>(config);
   if (res.success) return { type: 'success', value: res.body.reportId };
-  return generateError<ReportErrorCodes>(res.errorCode, REPORT_ERROR_MESSAGES, 'initReport');
+  return generateError<ReportErrorCodes>(
+    res.errorCode,
+    REPORT_ERROR_MESSAGES,
+    'initReport',
+    undefined,
+    res.jsonApiError,
+  );
 }
 
 /**
@@ -557,7 +569,13 @@ export async function getReport(options: GetReportOptions): Promise<Result<Uploa
 
   const res = await makeRequest<UploadReportResponseDto>(config);
   if (res.success) return { type: 'success', value: res.body };
-  return generateError<ReportErrorCodes>(res.errorCode, REPORT_ERROR_MESSAGES, 'getReport', res.error?.message);
+  return generateError<ReportErrorCodes>(
+    res.errorCode,
+    REPORT_ERROR_MESSAGES,
+    'getReport',
+    res.error?.message,
+    res.jsonApiError,
+  );
 }
 
 /**
@@ -588,7 +606,13 @@ export async function initScmReport(options: ScmUploadReportOptions): Promise<Re
 
   const res = await makeRequest<InitScmUploadResponseDto>(config);
   if (res.success) return { type: 'success', value: res.body.testId };
-  return generateError<ReportErrorCodes>(res.errorCode, REPORT_ERROR_MESSAGES, 'initReport');
+  return generateError<ReportErrorCodes>(
+    res.errorCode,
+    REPORT_ERROR_MESSAGES,
+    'initReport',
+    undefined,
+    res.jsonApiError,
+  );
 }
 
 /**
@@ -615,5 +639,11 @@ export async function getScmReport(
 
   const res = await makeRequest<UploadReportResponseDto>(config);
   if (res.success) return { type: 'success', value: res.body };
-  return generateError<ReportErrorCodes>(res.errorCode, REPORT_ERROR_MESSAGES, 'getReport', res.error?.message);
+  return generateError<ReportErrorCodes>(
+    res.errorCode,
+    REPORT_ERROR_MESSAGES,
+    'getReport',
+    res.error?.message,
+    res.jsonApiError,
+  );
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -14,14 +14,15 @@ import {
   ReportOptions,
   ScmReportOptions,
 } from './interfaces/analysis-options.interface';
-import { generateJsonApiError, getURL, isJsonApiErrors } from './utils/httpUtils';
+import { generateErrorWithDetail, getURL } from './utils/httpUtils';
+import { JsonApiError } from './interfaces/json-api';
 
 type ResultSuccess<T> = { type: 'success'; value: T };
 
 export type ResultError<E> = {
   type: 'error';
   error: {
-    statusCode: E | number;
+    statusCode: E;
     statusText: string;
     apiName: string;
     detail?: string | undefined;
@@ -51,10 +52,10 @@ function generateError<E>(
   messages: { [c: number]: string },
   apiName: string,
   errorMessage?: string,
-  errors?: unknown,
+  jsonApiError?: JsonApiError,
 ): ResultError<E> {
-  if (isJsonApiErrors(errors)) {
-    return generateJsonApiError<E>(errors, errorCode, apiName);
+  if (jsonApiError) {
+    return generateErrorWithDetail<E>(jsonApiError, errorCode, apiName);
   }
 
   if (!isSubsetErrorCode<E>(errorCode, messages)) {
@@ -279,7 +280,7 @@ export async function createBundle(
     CREATE_BUNDLE_ERROR_MESSAGES,
     'createBundle',
     undefined,
-    res.errors,
+    res.jsonApiError,
   );
 }
 
@@ -373,7 +374,7 @@ export async function extendBundle(
     EXTEND_BUNDLE_ERROR_MESSAGES,
     'extendBundle',
     undefined,
-    res.errors,
+    res.jsonApiError,
   );
 }
 
@@ -454,7 +455,7 @@ export async function getAnalysis(
     GET_ANALYSIS_ERROR_MESSAGES,
     'getAnalysis',
     undefined,
-    res.errors,
+    res.jsonApiError,
   );
 }
 

--- a/src/interfaces/json-api.ts
+++ b/src/interfaces/json-api.ts
@@ -1,0 +1,9 @@
+export type JsonApiError = {
+  links?: {
+    about?: string;
+  };
+  status: string;
+  code: string;
+  title: string;
+  detail: string;
+};

--- a/src/needle.ts
+++ b/src/needle.ts
@@ -45,10 +45,12 @@ interface SuccessResponse<T> {
   success: true;
   body: T;
 }
+
 export type FailedResponse = {
   success: false;
   errorCode: number;
   error: Error | undefined;
+  errors?: unknown;
 };
 
 export async function makeRequest<T = void>(
@@ -109,6 +111,9 @@ export async function makeRequest<T = void>(
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
     const errorMessage = response?.body?.error;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const errors = response?.body?.errors as unknown;
+
     if (errorMessage) {
       error = error ?? new Error(errorMessage);
     }
@@ -130,7 +135,7 @@ export async function makeRequest<T = void>(
       await sleep(REQUEST_RETRY_DELAY);
     } else {
       attempts = 0;
-      return { success: false, errorCode, error };
+      return { success: false, errorCode, error, errors };
     }
   } while (attempts > 0);
 

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -42,7 +42,9 @@ export function isJsonApiErrors(input: unknown): input is JsonApiError[] {
 
 export function generateErrorWithDetail<E>(error: JsonApiError, statusCode: number, apiName: string): ResultError<E> {
   const errorLink = error.links?.about;
-  const detail = `${error.title}: ${error.detail}${errorLink ? ` (more info: ${errorLink})` : ``}`;
+  const detail = `${error.title}${error.detail ? `: ${error.detail}` : ''}${
+    errorLink ? ` (more info: ${errorLink})` : ``
+  }`;
   const statusText = error.title;
   return {
     type: 'error',

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -21,7 +21,7 @@ function isValidOrg(orgId?: string): boolean {
 }
 
 export function isJsonApiErrors(input: unknown): input is JsonApiError[] {
-  if (!Array.isArray(input)) {
+  if (!Array.isArray(input) || input.length < 1) {
     return false;
   }
 

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -40,8 +40,7 @@ export function isJsonApiErrors(input: unknown): input is JsonApiError[] {
   return true;
 }
 
-export function generateJsonApiError<E>(errors: JsonApiError[], statusCode: number, apiName: string): ResultError<E> {
-  const error = errors[0];
+export function generateErrorWithDetail<E>(error: JsonApiError, statusCode: number, apiName: string): ResultError<E> {
   const errorLink = error.links?.about;
   const detail = `${error.title}: ${error.detail}${errorLink ? ` (more info: ${errorLink})` : ``}`;
   const statusText = error.title;
@@ -49,7 +48,7 @@ export function generateJsonApiError<E>(errors: JsonApiError[], statusCode: numb
     type: 'error',
     error: {
       apiName,
-      statusCode,
+      statusCode: statusCode as unknown as E,
       statusText,
       detail,
     },

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -1,4 +1,6 @@
 import { ORG_ID_REGEXP } from '../constants';
+import { JsonApiError } from '../interfaces/json-api';
+import { ResultError } from '../http';
 
 export function getURL(baseURL: string, path: string, orgId?: string): string {
   if (routeToGateway(baseURL)) {
@@ -16,4 +18,40 @@ function routeToGateway(baseURL: string): boolean {
 
 function isValidOrg(orgId?: string): boolean {
   return orgId !== undefined && ORG_ID_REGEXP.test(orgId);
+}
+
+export function isJsonApiErrors(input: unknown): input is JsonApiError[] {
+  if (!Array.isArray(input)) {
+    return false;
+  }
+
+  for (const element of input) {
+    if (
+      typeof element !== 'object' ||
+      !('status' in element) ||
+      !('code' in element) ||
+      !('title' in element) ||
+      !('detail' in element)
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function generateJsonApiError<E>(errors: JsonApiError[], statusCode: number, apiName: string): ResultError<E> {
+  const error = errors[0];
+  const errorLink = error.links?.about;
+  const detail = `${error.title}: ${error.detail}${errorLink ? ` (more info: ${errorLink})` : ``}`;
+  const statusText = error.title;
+  return {
+    type: 'error',
+    error: {
+      apiName,
+      statusCode,
+      statusText,
+      detail,
+    },
+  };
 }

--- a/tests/http.spec.ts
+++ b/tests/http.spec.ts
@@ -1,7 +1,7 @@
 import { createBundle, extendBundle, getAnalysis, getVerifyCallbackUrl, ResultError } from '../src/http';
 import { baseURL, source } from './constants/base';
 import * as needle from '../src/needle';
-import { GenericErrorTypes } from '../src/constants';
+import * as httpUtils from '../src/utils/httpUtils';
 
 const jsonApiError = {
   status: '422',
@@ -12,6 +12,8 @@ const jsonApiError = {
     about: 'https://snyk.io',
   },
 };
+
+const error = new Error('uh oh');
 
 describe('HTTP', () => {
   const authHost = 'https://dev.snyk.io';
@@ -64,11 +66,9 @@ describe('HTTP', () => {
     };
 
     it('should return error on failed response', async () => {
-      jest
-        .spyOn(needle, 'makeRequest')
-        .mockResolvedValue({ success: false, errorCode: 400, error: new Error('uh oh') });
+      jest.spyOn(needle, 'makeRequest').mockResolvedValue({ success: false, errorCode: 400, error });
 
-      const result = (await getAnalysis(options)) as ResultError<GenericErrorTypes>;
+      const result = (await getAnalysis(options)) as ResultError<number>;
 
       expect(result.error.apiName).toEqual('getAnalysis');
       expect(result.error.statusText).toBeTruthy();
@@ -76,16 +76,12 @@ describe('HTTP', () => {
     });
 
     it('should return error with detail for json api type errors on failed response', async () => {
-      jest
-        .spyOn(needle, 'makeRequest')
-        .mockResolvedValue({ success: false, errorCode: 422, error: new Error('uh oh'), errors: [jsonApiError] });
+      jest.spyOn(needle, 'makeRequest').mockResolvedValue({ success: false, errorCode: 422, error, jsonApiError });
+      const spy = jest.spyOn(httpUtils, 'generateErrorWithDetail');
 
-      const result = (await getAnalysis(options)) as ResultError<GenericErrorTypes>;
+      await getAnalysis(options);
 
-      expect(result.error.apiName).toEqual('getAnalysis');
-      expect(result.error.statusText).toBeTruthy();
-      expect(result.error.statusCode).toEqual(422);
-      expect(result.error.detail).toBeTruthy();
+      expect(spy).toHaveBeenCalledWith(jsonApiError, 422, 'getAnalysis');
     });
   });
 
@@ -100,11 +96,9 @@ describe('HTTP', () => {
     };
 
     it('should return error on failed response', async () => {
-      jest
-        .spyOn(needle, 'makeRequest')
-        .mockResolvedValue({ success: false, errorCode: 400, error: new Error('uh oh') });
+      jest.spyOn(needle, 'makeRequest').mockResolvedValue({ success: false, errorCode: 400, error });
 
-      const result = (await createBundle(options)) as ResultError<GenericErrorTypes>;
+      const result = (await createBundle(options)) as ResultError<number>;
 
       expect(result.error.apiName).toEqual('createBundle');
       expect(result.error.statusText).toBeTruthy();
@@ -112,16 +106,12 @@ describe('HTTP', () => {
     });
 
     it('should return error with detail for json api type errors on failed response', async () => {
-      jest
-        .spyOn(needle, 'makeRequest')
-        .mockResolvedValue({ success: false, errorCode: 422, error: new Error('uh oh'), errors: [jsonApiError] });
+      jest.spyOn(needle, 'makeRequest').mockResolvedValue({ success: false, errorCode: 422, error, jsonApiError });
+      const spy = jest.spyOn(httpUtils, 'generateErrorWithDetail');
 
-      const result = (await createBundle(options)) as ResultError<GenericErrorTypes>;
+      await createBundle(options);
 
-      expect(result.error.apiName).toEqual('createBundle');
-      expect(result.error.statusText).toBeTruthy();
-      expect(result.error.statusCode).toEqual(422);
-      expect(result.error.detail).toBeTruthy();
+      expect(spy).toHaveBeenCalledWith(jsonApiError, 422, 'createBundle');
     });
   });
 
@@ -136,11 +126,9 @@ describe('HTTP', () => {
     };
 
     it('should return error on failed response', async () => {
-      jest
-        .spyOn(needle, 'makeRequest')
-        .mockResolvedValue({ success: false, errorCode: 400, error: new Error('uh oh') });
+      jest.spyOn(needle, 'makeRequest').mockResolvedValue({ success: false, errorCode: 400, error });
 
-      const result = (await extendBundle(options)) as ResultError<GenericErrorTypes>;
+      const result = (await extendBundle(options)) as ResultError<number>;
 
       expect(result.error.apiName).toEqual('extendBundle');
       expect(result.error.statusText).toBeTruthy();
@@ -148,16 +136,12 @@ describe('HTTP', () => {
     });
 
     it('should return error with detail for json api type errors on failed response', async () => {
-      jest
-        .spyOn(needle, 'makeRequest')
-        .mockResolvedValue({ success: false, errorCode: 422, error: new Error('uh oh'), errors: [jsonApiError] });
+      jest.spyOn(needle, 'makeRequest').mockResolvedValue({ success: false, errorCode: 422, error, jsonApiError });
+      const spy = jest.spyOn(httpUtils, 'generateErrorWithDetail');
 
-      const result = (await extendBundle(options)) as ResultError<GenericErrorTypes>;
+      await extendBundle(options);
 
-      expect(result.error.apiName).toEqual('extendBundle');
-      expect(result.error.statusText).toBeTruthy();
-      expect(result.error.statusCode).toEqual(422);
-      expect(result.error.detail).toBeTruthy();
+      expect(spy).toHaveBeenCalledWith(jsonApiError, 422, 'extendBundle');
     });
   });
 });

--- a/tests/http.spec.ts
+++ b/tests/http.spec.ts
@@ -1,5 +1,17 @@
-import needle from 'needle';
-import { getVerifyCallbackUrl } from '../src/http';
+import { createBundle, extendBundle, getAnalysis, getVerifyCallbackUrl, ResultError } from '../src/http';
+import { baseURL, source } from './constants/base';
+import * as needle from '../src/needle';
+import { GenericErrorTypes } from '../src/constants';
+
+const jsonApiError = {
+  status: '422',
+  code: 'SNYK_0001',
+  title: 'bad error',
+  detail: 'detail',
+  links: {
+    about: 'https://snyk.io',
+  },
+};
 
 describe('HTTP', () => {
   const authHost = 'https://dev.snyk.io';
@@ -40,5 +52,112 @@ describe('HTTP', () => {
     const url = getVerifyCallbackUrl(authHost);
 
     expect(url).toBe(`${authHost}/api/verify/callback`);
+  });
+
+  describe('getAnalysis', () => {
+    const options = {
+      baseURL,
+      sessionToken: 'token',
+      bundleHash: '123',
+      severity: 1,
+      source,
+    };
+
+    it('should return error on failed response', async () => {
+      jest
+        .spyOn(needle, 'makeRequest')
+        .mockResolvedValue({ success: false, errorCode: 400, error: new Error('uh oh') });
+
+      const result = (await getAnalysis(options)) as ResultError<GenericErrorTypes>;
+
+      expect(result.error.apiName).toEqual('getAnalysis');
+      expect(result.error.statusText).toBeTruthy();
+      expect(result.error.statusCode).toEqual(400);
+    });
+
+    it('should return error with detail for json api type errors on failed response', async () => {
+      jest
+        .spyOn(needle, 'makeRequest')
+        .mockResolvedValue({ success: false, errorCode: 422, error: new Error('uh oh'), errors: [jsonApiError] });
+
+      const result = (await getAnalysis(options)) as ResultError<GenericErrorTypes>;
+
+      expect(result.error.apiName).toEqual('getAnalysis');
+      expect(result.error.statusText).toBeTruthy();
+      expect(result.error.statusCode).toEqual(422);
+      expect(result.error.detail).toBeTruthy();
+    });
+  });
+
+  describe('createBundle', () => {
+    const options = {
+      baseURL,
+      sessionToken: 'token',
+      bundleHash: '123',
+      severity: 1,
+      source,
+      files: {},
+    };
+
+    it('should return error on failed response', async () => {
+      jest
+        .spyOn(needle, 'makeRequest')
+        .mockResolvedValue({ success: false, errorCode: 400, error: new Error('uh oh') });
+
+      const result = (await createBundle(options)) as ResultError<GenericErrorTypes>;
+
+      expect(result.error.apiName).toEqual('createBundle');
+      expect(result.error.statusText).toBeTruthy();
+      expect(result.error.statusCode).toEqual(400);
+    });
+
+    it('should return error with detail for json api type errors on failed response', async () => {
+      jest
+        .spyOn(needle, 'makeRequest')
+        .mockResolvedValue({ success: false, errorCode: 422, error: new Error('uh oh'), errors: [jsonApiError] });
+
+      const result = (await createBundle(options)) as ResultError<GenericErrorTypes>;
+
+      expect(result.error.apiName).toEqual('createBundle');
+      expect(result.error.statusText).toBeTruthy();
+      expect(result.error.statusCode).toEqual(422);
+      expect(result.error.detail).toBeTruthy();
+    });
+  });
+
+  describe('extendBundle', () => {
+    const options = {
+      baseURL,
+      sessionToken: 'token',
+      bundleHash: '123',
+      severity: 1,
+      source,
+      files: {},
+    };
+
+    it('should return error on failed response', async () => {
+      jest
+        .spyOn(needle, 'makeRequest')
+        .mockResolvedValue({ success: false, errorCode: 400, error: new Error('uh oh') });
+
+      const result = (await extendBundle(options)) as ResultError<GenericErrorTypes>;
+
+      expect(result.error.apiName).toEqual('extendBundle');
+      expect(result.error.statusText).toBeTruthy();
+      expect(result.error.statusCode).toEqual(400);
+    });
+
+    it('should return error with detail for json api type errors on failed response', async () => {
+      jest
+        .spyOn(needle, 'makeRequest')
+        .mockResolvedValue({ success: false, errorCode: 422, error: new Error('uh oh'), errors: [jsonApiError] });
+
+      const result = (await extendBundle(options)) as ResultError<GenericErrorTypes>;
+
+      expect(result.error.apiName).toEqual('extendBundle');
+      expect(result.error.statusText).toBeTruthy();
+      expect(result.error.statusCode).toEqual(422);
+      expect(result.error.detail).toBeTruthy();
+    });
   });
 });

--- a/tests/httpUtils.spec.ts
+++ b/tests/httpUtils.spec.ts
@@ -1,4 +1,4 @@
-import { generateJsonApiError, getURL, isJsonApiErrors } from '../src/utils/httpUtils';
+import { generateErrorWithDetail, getURL, isJsonApiErrors } from '../src/utils/httpUtils';
 
 describe('getURL', () => {
   it('should return base + path if not fedramp', () => {
@@ -67,11 +67,11 @@ describe('isJsonApiErrors', () => {
     const jsonApiError = {
       status: '422',
     };
-    expect(isJsonApiErrors(jsonApiError)).toBeFalsy();
+    expect(isJsonApiErrors([jsonApiError])).toBeFalsy();
   });
 });
 
-describe('generateJsonApiError', () => {
+describe('generateErrorWithDetail', () => {
   it('should return detail with link', () => {
     const jsonApiError = {
       status: '422',
@@ -83,7 +83,7 @@ describe('generateJsonApiError', () => {
       },
     };
 
-    expect(generateJsonApiError([jsonApiError], 422, 'test')).toEqual({
+    expect(generateErrorWithDetail(jsonApiError, 422, 'test')).toEqual({
       type: 'error',
       error: {
         apiName: 'test',
@@ -102,7 +102,7 @@ describe('generateJsonApiError', () => {
       detail: 'detail',
     };
 
-    expect(generateJsonApiError([jsonApiError], 422, 'test')).toEqual({
+    expect(generateErrorWithDetail(jsonApiError, 422, 'test')).toEqual({
       type: 'error',
       error: {
         apiName: 'test',

--- a/tests/httpUtils.spec.ts
+++ b/tests/httpUtils.spec.ts
@@ -112,4 +112,45 @@ describe('generateErrorWithDetail', () => {
       },
     });
   });
+
+  it('should return detail with title and link when detail is empty string', () => {
+    const jsonApiError = {
+      status: '422',
+      code: 'SNYK_0001',
+      title: 'bad error',
+      detail: '',
+      links: {
+        about: 'https://snyk.io',
+      },
+    };
+
+    expect(generateErrorWithDetail(jsonApiError, 422, 'test')).toEqual({
+      type: 'error',
+      error: {
+        apiName: 'test',
+        statusCode: 422,
+        statusText: 'bad error',
+        detail: 'bad error (more info: https://snyk.io)',
+      },
+    });
+  });
+
+  it('should return detail with title when detail is empty string and no link', () => {
+    const jsonApiError = {
+      status: '422',
+      code: 'SNYK_0001',
+      title: 'bad error',
+      detail: '',
+    };
+
+    expect(generateErrorWithDetail(jsonApiError, 422, 'test')).toEqual({
+      type: 'error',
+      error: {
+        apiName: 'test',
+        statusCode: 422,
+        statusText: 'bad error',
+        detail: 'bad error',
+      },
+    });
+  });
 });


### PR DESCRIPTION
- [x] Ready for review
- [ ] Linked to Jira ticket

#### What does this PR do?

- Adds error handling for catalogue (json api format) errors to throw errors with a detail
- Handles analysis and create/extend bundle requests to detail [limit errors](https://docs.snyk.io/more-info/error-catalog#code) thrown by SAA and FBS
- Will be used in [this](https://github.com/snyk/cli/pull/4922) PR for the CLI to display error to the user
- User will see error message + user friendly detail + link to error catalogue

#### Screenshots
![Screenshot 2023-11-08 at 17 17 05](https://github.com/snyk/code-client/assets/24437295/e700aedd-d0f4-456d-8581-4d1015bf9e8b)

