### PR TITLE
fix: add posibility to add extra headers to filters endpoint

### DIFF
--- a/src/bundles.ts
+++ b/src/bundles.ts
@@ -220,9 +220,17 @@ export async function getSupportedFiles(
   requestId?: string,
   languages?: string[],
   orgId?: string,
+  extraHeaders?: Record<string, string>,
 ): Promise<SupportedFiles> {
   emitter.supportedFilesLoaded(null);
-  const resp = await getFilters(baseURL, source, MAX_RETRY_ATTEMPTS, requestId, orgId);
+  const resp = await getFilters({
+    baseURL,
+    source,
+    orgId,
+    requestId,
+    attempts: MAX_RETRY_ATTEMPTS,
+    extraHeaders: extraHeaders ?? {},
+  });
   if (resp.type === 'error') {
     throw resp.error;
   }
@@ -272,6 +280,7 @@ export async function createBundleFromFolders(options: CreateBundleFromFoldersOp
     options.requestId,
     options.languages,
     options.orgId,
+    options.extraHeaders,
   );
 
   // Collect files and create a remote bundle

--- a/src/http.ts
+++ b/src/http.ts
@@ -3,7 +3,7 @@ import pick from 'lodash.pick';
 import { gzip } from 'zlib';
 import { promisify } from 'util';
 
-import { DEFAULT_ERROR_MESSAGES, ErrorCodes, GenericErrorTypes, MAX_RETRY_ATTEMPTS } from './constants';
+import { DEFAULT_ERROR_MESSAGES, ErrorCodes, GenericErrorTypes } from './constants';
 
 import { BundleFiles, SupportedFiles } from './interfaces/files.interface';
 import { AnalysisResult, ReportResult } from './interfaces/analysis-result.interface';
@@ -180,13 +180,23 @@ export async function checkSession(options: CheckSessionOptions): Promise<Result
   return generateError<CheckSessionErrorCodes>(res.errorCode, CHECK_SESSION_ERROR_MESSAGES, 'checkSession');
 }
 
-export async function getFilters(
-  baseURL: string,
-  source: string,
-  attempts = MAX_RETRY_ATTEMPTS,
-  requestId?: string,
-  orgId?: string,
-): Promise<Result<SupportedFiles, GenericErrorTypes>> {
+export interface FilterArgs {
+  extraHeaders: Record<string, string>;
+  attempts: number;
+  baseURL: string;
+  source: string;
+  requestId?: string;
+  orgId?: string;
+}
+
+export async function getFilters({
+  baseURL,
+  orgId,
+  attempts,
+  source,
+  extraHeaders,
+  requestId,
+}: FilterArgs): Promise<Result<SupportedFiles, GenericErrorTypes>> {
   const apiName = 'filters';
   let url: string;
 
@@ -198,7 +208,11 @@ export async function getFilters(
 
   const res = await makeRequest<SupportedFiles>(
     {
-      headers: { source, ...(requestId && { 'snyk-request-id': requestId }) },
+      headers: {
+        source,
+        ...extraHeaders,
+        ...(requestId && { 'snyk-request-id': requestId }),
+      },
       url,
       method: 'get',
     },

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -3,7 +3,15 @@ import 'jest-extended';
 
 import { baseURL, sessionToken, source, TEST_TIMEOUT } from './constants/base';
 import { bundleFiles, bundleFilesFull, singleBundleFull } from './constants/sample';
-import { getFilters, createBundle, checkBundle, extendBundle, getAnalysis, AnalysisStatus } from '../src/http';
+import {
+  getFilters,
+  createBundle,
+  checkBundle,
+  extendBundle,
+  getAnalysis,
+  AnalysisStatus,
+  FilterArgs,
+} from '../src/http';
 import { BundleFiles } from '../src/interfaces/files.interface';
 
 const fakeBundleHash = '7055a4c63c339c31bdf28defcced19a64e5e87905b896befc522a11d35fbcdc4';
@@ -30,7 +38,7 @@ const fakeMissingFiles = [
 
 describe('Requests to public API', () => {
   it('gets filters successfully', async () => {
-    const response = await getFilters(baseURL, '');
+    const response = await getFilters({ baseURL, source: 'api-test', attempts: 1, extraHeaders: {} });
     expect(response.type).toEqual('success');
     if (response.type === 'error') return;
     expect(new Set(response.value.configFiles)).toEqual(new Set(['.dcignore', '.gitignore', '.snyk', '.snyk-rules']));
@@ -89,7 +97,12 @@ describe('Requests to public API', () => {
   });
 
   it('test network issues', async () => {
-    const response = await getFilters('https://faketest.snyk.io', 'test-source', 1);
+    const response = await getFilters({
+      baseURL: 'https://faketest.snyk.io',
+      source: 'test-source',
+      attempts: 1,
+      extraHeaders: {},
+    });
     expect(response.type).toEqual('error');
     if (response.type !== 'error') return;
     expect(response.error).toMatchObject({

--- a/tests/http.spec.ts
+++ b/tests/http.spec.ts
@@ -12,6 +12,7 @@ import {
 import { baseURL, source } from './constants/base';
 import * as needle from '../src/needle';
 import * as httpUtils from '../src/utils/httpUtils';
+import { FilterArgs } from '../src/http';
 
 const jsonApiError = {
   status: '422',
@@ -70,7 +71,7 @@ describe('HTTP', () => {
     it('should return error on failed response', async () => {
       jest.spyOn(needle, 'makeRequest').mockResolvedValue({ success: false, errorCode: 500, error });
 
-      const result = (await getFilters(baseURL, source)) as ResultError<number>;
+      const result = (await getFilters({ baseURL, source, attempts: 1, extraHeaders: {} })) as ResultError<number>;
 
       expect(result.error.apiName).toEqual('filters');
       expect(result.error.statusText).toBeTruthy();
@@ -81,7 +82,7 @@ describe('HTTP', () => {
       jest.spyOn(needle, 'makeRequest').mockResolvedValue({ success: false, errorCode: 422, error, jsonApiError });
       const spy = jest.spyOn(httpUtils, 'generateErrorWithDetail');
 
-      await getFilters(baseURL, source);
+      await getFilters({ baseURL, source, attempts: 1, extraHeaders: {} });
 
       expect(spy).toHaveBeenCalledWith(jsonApiError, 422, 'filters');
     });


### PR DESCRIPTION
- [ ] Ready for review
- [PUL2-771] Linked to Jira ticket

#### What does this PR do?

Getting the filters works without Authorization header in all environments. In FedRamp, this is not allowed, so I am addig the possibility to use the extra headers when getting the file extension in code-client.
This is required for the e2e test orb to work with FedRamp-Alpha.

[PUL2-771]: https://snyksec.atlassian.net/browse/PUL2-771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ