### PR TITLE
fix: downgrade needle for CONNECT mode proxy support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "lodash.pick": "^4.4.0",
         "lodash.union": "^4.6.0",
         "multimatch": "^5.0.0",
-        "needle": "~3.2.0",
+        "needle": "3.0.0",
         "p-map": "^3.0.0",
         "uuid": "^8.3.2",
         "yaml": "^1.10.2"
@@ -3865,7 +3865,6 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -5986,12 +5985,12 @@
       "license": "MIT"
     },
     "node_modules/needle": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-3.2.0.tgz",
-      "integrity": "sha512-oUvzXnyLiVyVGoianLijF9O/RecZUf7TkBfimjGrLM4eQhXyeJwM6GeAWccwfQ9aa4gMCZKqhAOuLaMIcQxajQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.0.0.tgz",
+      "integrity": "sha512-eGr0qnfHxAjr+Eptl1zr2lgUQUPC1SZfTkg2kFi0kxr1ChJonHUVYobkug8siBKMlyUVVp56MSkp6CSeXH/jgw==",
       "dependencies": {
         "debug": "^3.2.6",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.4.4",
         "sax": "^1.2.4"
       },
       "bin": {
@@ -6006,17 +6005,6 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
-      }
-    },
-    "node_modules/needle/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/nice-try": {
@@ -11205,7 +11193,6 @@
     },
     "iconv-lite": {
       "version": "0.4.24",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -12663,12 +12650,12 @@
       "dev": true
     },
     "needle": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-3.2.0.tgz",
-      "integrity": "sha512-oUvzXnyLiVyVGoianLijF9O/RecZUf7TkBfimjGrLM4eQhXyeJwM6GeAWccwfQ9aa4gMCZKqhAOuLaMIcQxajQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.0.0.tgz",
+      "integrity": "sha512-eGr0qnfHxAjr+Eptl1zr2lgUQUPC1SZfTkg2kFi0kxr1ChJonHUVYobkug8siBKMlyUVVp56MSkp6CSeXH/jgw==",
       "requires": {
         "debug": "^3.2.6",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.4.4",
         "sax": "^1.2.4"
       },
       "dependencies": {
@@ -12676,14 +12663,6 @@
           "version": "3.2.7",
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "lodash.pick": "^4.4.0",
     "lodash.union": "^4.6.0",
     "multimatch": "^5.0.0",
-    "needle": "~3.2.0",
+    "needle": "3.0.0",
     "p-map": "^3.0.0",
     "uuid": "^8.3.2",
     "yaml": "^1.10.2"


### PR DESCRIPTION
- Downgrades needle to 3.0.0
- See https://github.com/snyk/cli/pull/4953 for the corresponding CLI change
- See https://github.com/tomas/needle/issues/406 for the bug report in needle