### PR TITLE
fix: upgrade needle and disable proxy in needle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,14 +20,14 @@
         "lodash.pick": "^4.4.0",
         "lodash.union": "^4.6.0",
         "multimatch": "^5.0.0",
-        "needle": "3.0.0",
+        "needle": "^3.3.0",
         "p-map": "^3.0.0",
         "uuid": "^8.3.2",
         "yaml": "^1.10.2"
       },
       "devDependencies": {
         "@types/jest": "^26.0.12",
-        "@types/needle": "^2.5.2",
+        "@types/needle": "^3.3.0",
         "@types/node": "^14.6.2",
         "@types/write": "^2.0.1",
         "@typescript-eslint/eslint-plugin": "^4.31.2",
@@ -1171,9 +1171,10 @@
       "license": "MIT"
     },
     "node_modules/@types/needle": {
-      "version": "2.5.2",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@types/needle/-/needle-3.3.0.tgz",
+      "integrity": "sha512-UFIuc1gdyzAqeVUYpSL+cliw2MmU/ZUhVZKE7Zo4wPbgc8hbljeKSnn6ls6iG8r5jpegPXLUIhJ+Wb2kLVs8cg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -3865,6 +3866,7 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -5939,6 +5941,7 @@
     },
     "node_modules/ms": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/multimatch": {
@@ -5985,12 +5988,11 @@
       "license": "MIT"
     },
     "node_modules/needle": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-3.0.0.tgz",
-      "integrity": "sha512-eGr0qnfHxAjr+Eptl1zr2lgUQUPC1SZfTkg2kFi0kxr1ChJonHUVYobkug8siBKMlyUVVp56MSkp6CSeXH/jgw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.0.tgz",
+      "integrity": "sha512-Kaq820952NOrLY/LVbIhPZeXtCGDBAPVgT0BYnoT3p/Nr3nkGXdvWXXA3zgy7wpAgqRULu9p/NvKiFo6f/12fw==",
       "dependencies": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
+        "iconv-lite": "^0.6.3",
         "sax": "^1.2.4"
       },
       "bin": {
@@ -6000,11 +6002,15 @@
         "node": ">= 4.4.x"
       }
     },
-    "node_modules/needle/node_modules/debug": {
-      "version": "3.2.7",
-      "license": "MIT",
+    "node_modules/needle/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dependencies": {
-        "ms": "^2.1.1"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/nice-try": {
@@ -9428,7 +9434,9 @@
       "version": "3.0.4"
     },
     "@types/needle": {
-      "version": "2.5.2",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@types/needle/-/needle-3.3.0.tgz",
+      "integrity": "sha512-UFIuc1gdyzAqeVUYpSL+cliw2MmU/ZUhVZKE7Zo4wPbgc8hbljeKSnn6ls6iG8r5jpegPXLUIhJ+Wb2kLVs8cg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -11193,6 +11201,7 @@
     },
     "iconv-lite": {
       "version": "0.4.24",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -12616,7 +12625,8 @@
       "dev": true
     },
     "ms": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "dev": true
     },
     "multimatch": {
       "version": "5.0.0",
@@ -12650,19 +12660,20 @@
       "dev": true
     },
     "needle": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-3.0.0.tgz",
-      "integrity": "sha512-eGr0qnfHxAjr+Eptl1zr2lgUQUPC1SZfTkg2kFi0kxr1ChJonHUVYobkug8siBKMlyUVVp56MSkp6CSeXH/jgw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.0.tgz",
+      "integrity": "sha512-Kaq820952NOrLY/LVbIhPZeXtCGDBAPVgT0BYnoT3p/Nr3nkGXdvWXXA3zgy7wpAgqRULu9p/NvKiFo6f/12fw==",
       "requires": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
+        "iconv-lite": "^0.6.3",
         "sax": "^1.2.4"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.2.7",
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
           "requires": {
-            "ms": "^2.1.1"
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.12",
-    "@types/needle": "^2.5.2",
+    "@types/needle": "^3.3.0",
     "@types/node": "^14.6.2",
     "@types/write": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^4.31.2",
@@ -86,7 +86,7 @@
     "lodash.pick": "^4.4.0",
     "lodash.union": "^4.6.0",
     "multimatch": "^5.0.0",
-    "needle": "3.0.0",
+    "needle": "^3.3.0",
     "p-map": "^3.0.0",
     "uuid": "^8.3.2",
     "yaml": "^1.10.2"

--- a/src/needle.ts
+++ b/src/needle.ts
@@ -80,6 +80,7 @@ export async function makeRequest<T = void>(
   }
 
   const options: needle.NeedleOptions = {
+    use_proxy_from_env_var: false,
     headers: payload.headers,
     open_timeout: TIMEOUT_DEFAULT, // No timeout
     response_timeout: payload.timeout || TIMEOUT_DEFAULT,


### PR DESCRIPTION
Upgrades needle and disables needle from picking up the proxy based on environment variables.

Essentially reverting the temporary downgrade of https://github.com/snyk/code-client/pull/217 and properly fixing proxy support.


Related to https://github.com/snyk/cli/pull/4967

- [x] Upgrades needle to 3.3.0 (known to break CONNECT)
- [x] Disables proxy in needle, introduced in https://github.com/tomas/needle/pull/427
- [x] Upgrades `@types/needle` to support the new option introduced in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67880


