### PR TITLE
fix: add code-client-integration-test context to tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,9 @@ workflows:
             parameters:
               node_version: ['10.24.0', '12.22.7']
               package-lock: ['locked-dependencies', 'no-package-lock']
-          context: nodejs-install
+          context:
+            - nodejs-install
+            - code-client-integration-test
           requires:
             - lint
       - release:


### PR DESCRIPTION
These secrets were previously injected via project-specific environment variables. The secrets have been regenerated and moved into a [CircleCI context](https://app.circleci.com/settings/organization/github/snyk/contexts/4dc64971-d968-4f6c-812f-37caec3ab934).