### PR TITLE
Deprecate legacy authentication helper functions

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -100,6 +100,9 @@ export async function compressAndEncode(payload: unknown): Promise<Buffer> {
   return await deflate(Buffer.from(JSON.stringify(payload)).toString('base64'));
 }
 
+/**
+ * @deprecated This legacy authentication helper is kept for compatibility only and is not used by current internal consumers.
+ */
 export function startSession(options: StartSessionOptions): StartSessionResponseDto {
   const { source, authHost } = options;
   const draftToken = uuidv4();
@@ -116,6 +119,8 @@ export function getVerifyCallbackUrl(authHost: string): string {
 
 export type IpFamily = 6 | undefined;
 /**
+ * @deprecated This legacy authentication helper is kept for compatibility only and is not used by current internal consumers.
+ *
  * Dispatches a FORCED IPv6 request to test client's ISP and network capability.
  *
  * @return {number} IP family number used by the client.
@@ -156,6 +161,9 @@ interface CheckSessionOptions {
   readonly ipFamily?: IpFamily;
 }
 
+/**
+ * @deprecated This legacy authentication helper is kept for compatibility only and is not used by current internal consumers.
+ */
 export async function checkSession(options: CheckSessionOptions): Promise<Result<string, CheckSessionErrorCodes>> {
   const defaultValue: ResultSuccess<string> = {
     type: 'success',


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Linked to Jira ticket

#### What does this PR do?

Adds deprecation warnings to legacy authentication helper functions `startSession`, `testIpv6`, and `checkSession` to indicate they are maintained for compatibility only and are no longer used by current internal consumers.

#### Where should the reviewer start?

Review the added `@deprecated` JSDoc comments in `src/http.ts` for the three authentication helper functions.

#### How should this be manually tested?

Verify that the deprecation warnings appear in IDEs and development tools when these functions are imported or used in code.

#### Any background context you want to provide?

These authentication helpers appear to be legacy code that is being phased out but maintained for backward compatibility with existing external consumers.

#### Screenshots

N/A

#### Additional questions

Should we consider adding a timeline for when these deprecated functions might be removed entirely?