### PR TITLE
Update documentation to focus on analyzeFolders API over legacy authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,32 +25,34 @@ import codeClient from '@snyk/code-client';
 const baseURL = 'https://www.snyk.io';
 ```
 
-### Requests the creation of a new login session
+`@snyk/code-client` is primarily used for Snyk Code scanning, bundle creation, and reporting APIs. The older authentication helpers are still exported for compatibility, but they are legacy and are not used by current internal consumers.
+
+### Run analysis
 
 ```javascript
-const loginResponse = await codeClient.startSession({
-  baseURL,
-  // An identificator for the editor using the Snyk APIs
-  source: 'atom',
+const authorization = process.env.SNYK_OAUTH_TOKEN
+  ? `Bearer ${process.env.SNYK_OAUTH_TOKEN}`
+  : `token ${process.env.SNYK_API_KEY}`;
+
+const result = await codeClient.analyzeFolders({
+  connection: {
+    baseURL,
+    sessionToken: authorization,
+    source: 'cli',
+  },
+  analysisOptions: {
+    severity: codeClient.AnalysisSeverity.info,
+  },
+  fileOptions: {
+    paths: ['.'],
+  },
 });
-
-if (loginResponse.type === 'error') {
-  // Handle error and alert user
-}
-
-const { sessionToken, loginURL } = loginResponse.value;
 ```
 
-### Checks status of the login process
+`sessionToken` is sent as the `Authorization` header value. Follow the same pattern used by current internal consumers:
 
-```javascript
-const sessionResponse = await codeClient.checkSession({ baseURL, sessionToken });
-if (sessionResponse.type === 'error') {
-  // Handle error and alert user
-}
-
-const isLoggedIn = sessionResponse.value; // boolean
-```
+- OAuth: `Bearer <access-token>`
+- API token: `token <api-key>`
 
 ### Subscribe to events.
 

--- a/development.md
+++ b/development.md
@@ -21,13 +21,14 @@ $ npm link @snyk/code-client
 Test variables:
 
 - `SNYK_API_HOST` is the API server host (by default: https://deeproxy.dev.snyk.io)
-- `SNYK_AUTH_HOST` is the Snyk authentication server host (by default: https://dev.snyk.io)
 - `SNYK_API_KEY` is a sessionToken of a user with access to the Snyk
 
 ```shell script
 $ cd <package-location>
-$ SNYK_API_HOST=... SNYK_AUTH_HOST=... SNYK_API_KEY=... npm run test
+$ SNYK_API_HOST=... SNYK_API_KEY=... npm run test
 ```
+
+Note: the legacy authentication helpers exported by `@snyk/code-client` are kept for compatibility, but they are not part of the test suite and are not used by current internal consumers.
 
 #### Publish
 


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Linked to Jira ticket

#### What does this PR do?

Updates documentation to reflect the current usage patterns of `@snyk/code-client`. Replaces the legacy authentication flow examples with the modern `analyzeFolders` API that uses OAuth tokens or API keys directly. Clarifies that authentication helpers are maintained for compatibility but are no longer used by internal consumers.

#### Where should the reviewer start?

Review the README.md changes to see the new API usage examples, particularly the `analyzeFolders` method and authorization header patterns.

#### How should this be manually tested?

Test the updated code examples in the README to ensure they work with both OAuth tokens (`Bearer <token>`) and API keys (`token <key>`). Verify that the `analyzeFolders` API functions as documented.

#### Any background context you want to provide?

The legacy authentication flow (`startSession`/`checkSession`) is being phased out in favor of direct token usage. This documentation update aligns with current internal usage patterns while maintaining backward compatibility.

#### Screenshots

N/A

#### Additional questions

Should we consider adding deprecation warnings to the legacy authentication methods in a future release?