### PR TITLE
ci: update test matrix to Node 18 + 20, drop Node 10/12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,8 +90,7 @@ jobs:
           command: npm install
       - run:
           name: Publish to GitHub
-          ## this is a work around, as it seems that the latest version has issues with < node14
-          command: npx semantic-release@16
+          command: npx semantic-release
 
 workflows:
   default_workflow:
@@ -105,17 +104,17 @@ workflows:
               ignore:
                 - master
       - security-scans:
-          node_version: '12.22.7'
+          node_version: '20.19.2'
           name: Security Scans
           context:
             - prodsec-orb-runtime
             - codesec_code-integrations
       - lint:
-          node_version: '12.22.7'
+          node_version: '20.19.2'
       - test:
           matrix:
             parameters:
-              node_version: ['10.24.0', '12.22.7']
+              node_version: ['18.20.8', '20.19.2']
               package-lock: ['locked-dependencies', 'no-package-lock']
           context:
             - nodejs-install
@@ -123,7 +122,7 @@ workflows:
           requires:
             - lint
       - release:
-          node_version: '12.22.7'
+          node_version: '20.19.2'
           context: nodejs-lib-release
           requires:
             - lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,9 @@
         "ts-node": "^10.9.1",
         "typescript": "^4.0.2",
         "write": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@snyk/code-client",
   "description": "Typescript consumer of SnykCode public API",
   "main": "dist/index.js",
-  "module": "dist/index.es.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"
@@ -34,6 +33,9 @@
     "url": "https://github.com/snyk/code-client/issues"
   },
   "homepage": "https://github.com/snyk/code-client#readme",
+  "engines": {
+    "node": ">=18"
+  },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",


### PR DESCRIPTION
## Summary

- Update CircleCI test matrix from Node 10/12 (both EOL) to Node 18/20 (current LTS lines)
- Update lint, security scans, and release jobs to Node 20
- Remove pinned `semantic-release@16` (was pinned due to Node < 14 incompatibility)

This is a prerequisite for all subsequent dependency upgrades in this stack, since Jest 29, TypeScript 5, and ESLint 8 all require Node >= 14 at minimum.

## Test plan

- [ ] CI passes on Node 18.20.8 and 20.19.2
- [ ] Lint job succeeds on Node 20
- [ ] Release job works with unpinned semantic-release
