### PR TITLE
chore: upgrade uuid 11, yaml 2, needle latest; remove @types/uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,17 +13,16 @@
         "@types/lodash.pick": "^4.4.8",
         "@types/lodash.union": "^4.6.7",
         "@types/sarif": "^2.1.6",
-        "@types/uuid": "^8.3.4",
         "fast-glob": "^3.3.2",
         "ignore": "^5.2.4",
         "lodash.omit": "^4.5.0",
         "lodash.pick": "^4.4.0",
         "lodash.union": "^4.6.0",
         "minimatch": "^10.2.5",
-        "needle": "^3.3.0",
+        "needle": "^3.5.0",
         "p-map": "^3.0.0",
-        "uuid": "^8.3.2",
-        "yaml": "^1.10.3"
+        "uuid": "^11.1.0",
+        "yaml": "^2.8.3"
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
@@ -1546,11 +1545,6 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "node_modules/@types/write": {
       "version": "2.0.4",
@@ -5716,9 +5710,10 @@
       "dev": true
     },
     "node_modules/needle": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
-      "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.5.0.tgz",
+      "integrity": "sha512-jaQyPKKk2YokHrEg+vFDYxXIHTCBgiZwSHOoVx/8V3GIBS8/VN6NdVRmg8q1ERtPkMvmOvebsgga4sAj5hls/w==",
+      "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.3",
         "sax": "^1.2.4"
@@ -7706,11 +7701,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -7942,11 +7942,18 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -81,16 +81,15 @@
     "@types/lodash.pick": "^4.4.8",
     "@types/lodash.union": "^4.6.7",
     "@types/sarif": "^2.1.6",
-    "@types/uuid": "^8.3.4",
     "fast-glob": "^3.3.2",
     "ignore": "^5.2.4",
     "lodash.omit": "^4.5.0",
     "lodash.pick": "^4.4.0",
     "lodash.union": "^4.6.0",
     "minimatch": "^10.2.5",
-    "needle": "^3.3.0",
+    "needle": "^3.5.0",
     "p-map": "^3.0.0",
-    "uuid": "^8.3.2",
-    "yaml": "^1.10.3"
+    "uuid": "^11.1.0",
+    "yaml": "^2.8.3"
   }
 }


### PR DESCRIPTION
## Summary

- Upgrade `uuid` from 8 to 11 (last CJS-compatible major; 12+ is ESM-only) and remove `@types/uuid` (uuid 11 bundles its own types)
- Upgrade `yaml` from 1 to 2 (the `parse()` API is compatible; verified with existing test fixtures)
- Upgrade `needle` to latest 3.x patch

## Test plan

- [ ] `tests/file-ignores.spec.ts` passes (yaml v2 parses `.snyk` files correctly)
- [ ] Build succeeds
- [ ] All unit tests pass
