### PR TITLE
fix(ci): migrate to NPM OIDC trusted publishing [COIN-2491]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,8 +89,10 @@ jobs:
           name: Install
           command: npm install
       - run:
-          name: Publish to GitHub
-          command: npx semantic-release
+          name: Publish to NPM and GitHub
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            npx semantic-release
 
 workflows:
   default_workflow:
@@ -123,7 +125,9 @@ workflows:
             - lint
       - release:
           node_version: '24.15.0'
-          context: nodejs-lib-release
+          context:
+            - nodejs-install
+            - github-release
           requires:
             - lint
           filters:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/snyk/code-client.git"
+    "url": "https://github.com/snyk/code-client.git"
   },
   "keywords": [
     "snyk",
@@ -29,6 +29,9 @@
   ],
   "author": "snyk",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "bugs": {
     "url": "https://github.com/snyk/code-client/issues"
   },


### PR DESCRIPTION
- Update package.json to follow npm Packages Security Standard:
  - Normalize repository.url (drop git+ prefix per standard)
  - Add publishConfig.access=public for the public scoped package
- Migrate CircleCI release job to NPM OIDC Trusted Publishing:
  - Export NPM_ID_TOKEN from CircleCI OIDC before semantic-release
  - Replace nodejs-lib-release context with nodejs-install + github-release

Provenance is handled automatically by @semantic-release/npm v13.1.0+,
which npx pulls on each release run, so no manual --provenance flag is
needed. The fix(ci) commit type triggers a release as an end-to-end test
of the new OIDC flow.