### PR TITLE
chore: pin min-release-age to 4 days

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,9 @@ jobs:
           keys:
             - v2-{{ .Branch }}-{{ .Revision }}-<< parameters.node_version >>
       - run:
+          name: Ensure npm >= 11.12.1
+          command: sudo npm install --location=global npm@^11.12.1
+      - run:
           name: Install
           command: npm install
       - prodsec/security_scans:
@@ -38,6 +41,9 @@ jobs:
       - restore_cache:
           keys:
             - v2-{{ .Branch }}-{{ .Revision }}-<< parameters.node_version >>>-<< parameters.package-lock >>>
+      - run:
+          name: Ensure npm >= 11.12.1
+          command: sudo npm install --location=global npm@^11.12.1
       - when:
           condition: << parameters.package-lock >> == "locked-dependencies"
           steps:
@@ -69,6 +75,9 @@ jobs:
           keys:
             - v2-{{ .Branch }}-{{ .Revision }}-<< parameters.node_version >>
       - run:
+          name: Ensure npm >= 11.12.1
+          command: sudo npm install --location=global npm@^11.12.1
+      - run:
           name: Install
           command: npm install
       - run: npm run lint
@@ -85,6 +94,9 @@ jobs:
       - restore_cache:
           keys:
             - v2-{{ .Branch }}-{{ .Revision }}-<< parameters.node_version >>
+      - run:
+          name: Ensure npm >= 11.12.1
+          command: sudo npm install --location=global npm@^11.12.1
       - run:
           name: Install
           command: npm install
@@ -114,7 +126,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              node_version: ['18.20.8', '20.19.2']
+              node_version: ['20.19.2', '24.15.0']
               package-lock: ['locked-dependencies', 'no-package-lock']
           context:
             - nodejs-install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,6 @@ jobs:
           keys:
             - v2-{{ .Branch }}-{{ .Revision }}-<< parameters.node_version >>
       - run:
-          name: Ensure npm >= 11.12.1
-          command: sudo npm install --location=global npm@^11.12.1
-      - run:
           name: Install
           command: npm install
       - prodsec/security_scans:
@@ -41,9 +38,6 @@ jobs:
       - restore_cache:
           keys:
             - v2-{{ .Branch }}-{{ .Revision }}-<< parameters.node_version >>>-<< parameters.package-lock >>>
-      - run:
-          name: Ensure npm >= 11.12.1
-          command: sudo npm install --location=global npm@^11.12.1
       - when:
           condition: << parameters.package-lock >> == "locked-dependencies"
           steps:
@@ -75,9 +69,6 @@ jobs:
           keys:
             - v2-{{ .Branch }}-{{ .Revision }}-<< parameters.node_version >>
       - run:
-          name: Ensure npm >= 11.12.1
-          command: sudo npm install --location=global npm@^11.12.1
-      - run:
           name: Install
           command: npm install
       - run: npm run lint
@@ -94,9 +85,6 @@ jobs:
       - restore_cache:
           keys:
             - v2-{{ .Branch }}-{{ .Revision }}-<< parameters.node_version >>
-      - run:
-          name: Ensure npm >= 11.12.1
-          command: sudo npm install --location=global npm@^11.12.1
       - run:
           name: Install
           command: npm install
@@ -116,17 +104,17 @@ workflows:
               ignore:
                 - master
       - security-scans:
-          node_version: '20.19.2'
+          node_version: '24.15.0'
           name: Security Scans
           context:
             - prodsec-orb-runtime
             - codesec_code-integrations
       - lint:
-          node_version: '20.19.2'
+          node_version: '24.15.0'
       - test:
           matrix:
             parameters:
-              node_version: ['20.19.2', '24.15.0']
+              node_version: ['24.15.0']
               package-lock: ['locked-dependencies', 'no-package-lock']
           context:
             - nodejs-install
@@ -134,7 +122,7 @@ workflows:
           requires:
             - lint
       - release:
-          node_version: '20.19.2'
+          node_version: '24.15.0'
           context: nodejs-lib-release
           requires:
             - lint

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+min-release-age=4
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "homepage": "https://github.com/snyk/code-client#readme",
   "engines": {
-    "node": ">=18"
+    "node": ">=20.17.0",
+    "npm": "^11.12.1"
   },
   "jest": {
     "preset": "ts-jest",


### PR DESCRIPTION
Adds npm 11's min-release-age=4 and engine-strict=true to .npmrc to prevent installation of newly published package versions for at least 4 days — protects against supply chain attacks that rely on rapid automated consumption of malicious packages. Bumps engines.node to >=20.17.0 (npm 11.10+ requirement) and pins engines.npm to ^11.12.1. Refs COIN-2485.