### PR TITLE
fix: replace lodash.pick with internal pick util

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,10 @@
       "dependencies": {
         "@deepcode/dcignore": "^1.0.4",
         "@types/lodash.omit": "^4.5.7",
-        "@types/lodash.pick": "^4.4.8",
         "@types/lodash.union": "^4.6.7",
         "@types/sarif": "^2.1.6",
         "fast-glob": "^3.3.2",
         "lodash.omit": "^4.5.0",
-        "lodash.pick": "^4.4.0",
         "lodash.union": "^4.6.0",
         "minimatch": "^10.2.5",
         "needle": "^3.5.0",
@@ -46,7 +44,8 @@
         "write": "^2.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.17.0",
+        "npm": "^11.12.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1488,14 +1487,6 @@
       "version": "4.5.9",
       "resolved": "https://registry.npmjs.org/@types/lodash.omit/-/lodash.omit-4.5.9.tgz",
       "integrity": "sha512-zuAVFLUPJMOzsw6yawshsYGgq2hWUHtsZgeXHZmSFhaQQFC6EQ021uDKHkSjOpNhSvtNSU9165/o3o/Q51GpTw==",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
-    "node_modules/@types/lodash.pick": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.pick/-/lodash.pick-4.4.9.tgz",
-      "integrity": "sha512-hDpr96x9xHClwy1KX4/RXRejqjDFTEGbEMT3t6wYSYeFDzxmMnSKB/xHIbktRlPj8Nii2g8L5dtFDRaNFBEzUQ==",
       "dependencies": {
         "@types/lodash": "*"
       }
@@ -5562,11 +5553,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
       "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg=="
-    },
-    "node_modules/lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q=="
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -78,12 +78,10 @@
   "dependencies": {
     "@deepcode/dcignore": "^1.0.4",
     "@types/lodash.omit": "^4.5.7",
-    "@types/lodash.pick": "^4.4.8",
     "@types/lodash.union": "^4.6.7",
     "@types/sarif": "^2.1.6",
     "fast-glob": "^3.3.2",
     "lodash.omit": "^4.5.0",
-    "lodash.pick": "^4.4.0",
     "lodash.union": "^4.6.0",
     "minimatch": "^10.2.5",
     "needle": "^3.5.0",

--- a/src/bundles.ts
+++ b/src/bundles.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-await-in-loop */
-import pick from 'lodash.pick';
 import omit from 'lodash.omit';
+import { pick } from './utils/pick';
 import pMap from 'p-map';
 
 import { BundleFiles, FileInfo, SupportedFiles } from './interfaces/files.interface';

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import pick from 'lodash.pick';
+import { pick } from './utils/pick';
 import { gzip } from 'zlib';
 import { promisify } from 'util';
 

--- a/src/report.ts
+++ b/src/report.ts
@@ -1,5 +1,5 @@
 import * as uuid from 'uuid';
-import pick from 'lodash.pick';
+import { pick } from './utils/pick';
 import { POLLING_INTERVAL } from './constants';
 import { emitter } from './emitter';
 import {

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -1,4 +1,4 @@
-import pick from 'lodash.pick';
+import { pick } from '../src/utils/pick';
 import 'jest-extended';
 
 import { baseURL, sessionToken, source, TEST_TIMEOUT } from './constants/base';


### PR DESCRIPTION
lodash.pick@4.4.0 is flagged for prototype pollution (GHSA, high) and has no patched release. All call sites pass hard-coded string-literal key lists, so swap the dependency for the existing typed src/utils/pick.ts helper (Object.hasOwn-based, no prototype-pollution surface) and drop the lodash.pick + @types/lodash.pick dependencies.
