### PR TITLE
chore: rename CODEOWNERS teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Snyk Code will be required for a review on every PR
 
-* @snyk/code_code-integrations
+* @snyk/engines_code-integrations


### PR DESCRIPTION
- [x] Ready for review
- [ ] Linked to Jira ticket. No ticket was provided.

#### What does this PR do?

This PR updates `.github/CODEOWNERS` with the 2026-Q3 GitHub team names.

Team renames:
- `@snyk/code_code-integrations` to `@snyk/engines_code-integrations`

#### Where should the reviewer start?

Review `.github/CODEOWNERS`.

#### How should this be manually tested?

Confirm that each new GitHub team exists.

#### Any background context you want to provide?

See the team rename sheet below.

#### Screenshots

Not applicable.

#### Additional questions

None.

- [Team rename sheet](https://docs.google.com/spreadsheets/d/1I6v4U8q1tuOj0XMp3uldTR8Q1B-N4HGnK1bMwkInpdw/edit?gid=1187079273#gid=1187079273)
- Jira ticket: Not provided.